### PR TITLE
Remove sanic tempfile hack

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ have been installed.  Defaults to `/opt/nvidia`.
 
 Other settings for configuring the underlying Sanic framework can also be provided.
 
+### Timeouts
+
+Some signing operations (particularly for bootloader update payloads and Mender
+artifacts) can take several minutes to complete, so the server configuration
+sets a default `RESPONSE_TIMEOUT` of five minutes. You may need to increase this
+setting, depending on your server hardware and expected service load. You should
+also configure  client-side timeouts and retries to guard against signing failures
+caused by  service timeouts under load.
+
 ## Running
 Once installed, use the `digsigserver` command to start the server:
 

--- a/digsigserver/server.py
+++ b/digsigserver/server.py
@@ -16,7 +16,7 @@ from . import utils
 # Signing can take a loooong time, so set a more reasonable
 # default response timeout
 CodesignSanicDefaults = {
-    'RESPONSE_TIMEOUT': 180,
+    'RESPONSE_TIMEOUT': 600,
     'L4T_TOOLS_BASE': '/opt/nvidia',
     'KEYFILE_URI': 'file:///please/configure/this/path',
     'LOG_LEVEL': 'INFO'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='digsigserver',
-    version='0.6.2',
+    version='0.6.99',
     packages=find_packages(),
     license='MIT',
     author='Matt Madison',
@@ -12,5 +12,5 @@ setup(
             'digsigserver = digsigserver.scripts.digsigserver:main',
         ]
     },
-    install_requires=['sanic==21.3.4']
+    install_requires=['sanic>=21.3']
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='digsigserver',
-    version='0.6.99',
+    version='0.7.0',
     packages=find_packages(),
     license='MIT',
     author='Matt Madison',


### PR DESCRIPTION
* Replaced the request wrapper hack for handling deletion of temporary files created during signing with a custom `return_file` function that streams the content of a file and deletes it. This is compatible with more-recent Sanic releases.
* Updated sanic dependency to require at least version 21.3.
* Ran stress tests to verify proper operation under load (64 simultaneous signings), and adjusted the default `RESPONSE_TIMEOUT` value upward to prevent false failures under load. Also see the latest update to the client-side `curl` invocations that sets higher connection and max timeouts and adds retries to guard against false failures when the signing server is loaded.
* Bumped version to 0.7.0.