### PR TITLE
Resolve Sanic breaking API changes introduced in 22.9.0.

### DIFF
--- a/digsigserver/scripts/digsigserver.py
+++ b/digsigserver/scripts/digsigserver.py
@@ -1,7 +1,9 @@
 import argparse
 import os
 import sys
-from digsigserver.server import app
+from sanic import Sanic
+from sanic.worker.loader import AppLoader
+from digsigserver.server import create_app
 
 
 def main():
@@ -12,7 +14,10 @@ def main():
     args = parser.parse_args()
     if not os.getenv('DIGSIGSERVER_KEYFILE_URI'):
         raise RuntimeError('Environment variable DIGSIGSERVER_KEYFILE_URI not set')
-    app.run(host=args.address, port=args.port, debug=args.debug)
+    loader = AppLoader(factory=create_app)
+    app = loader.load()
+    app.prepare(host=args.address, port=args.port, dev=args.debug)
+    Sanic.serve(primary=app, app_loader=loader)
 
 
 if __name__ == '__main__':

--- a/digsigserver/server.py
+++ b/digsigserver/server.py
@@ -30,14 +30,17 @@ CodesignSanicDefaults = {
 """
 Actual initialization happens here
 """
-app = Sanic(name='digsigserver', env_prefix='DIGSIGSERVER_')
-app.config.update_config(CodesignSanicDefaults)
-app.config.load_environment_vars(prefix='DIGSIGSERVER_')
-logger.setLevel(app.config.get("LOG_LEVEL"))
+def create_app() -> Sanic:
+    app = Sanic(name='digsigserver', env_prefix='DIGSIGSERVER_')
+    app.config.update_config(CodesignSanicDefaults)
+    app.config.load_environment_vars(prefix='DIGSIGSERVER_')
+    logger.setLevel(app.config.get("LOG_LEVEL"))
+    attach_endpoints(app)
+    return app
 
 
 def config_get(item: str, default_value=None) -> str:
-    return app.config.get(item, default_value)
+    return Sanic.get_app('digsigserver').config.get(item, default_value)
 
 
 def validate_upload(req: request, name: str, ok_types: Optional[list] = None) -> request.File:
@@ -84,145 +87,146 @@ async def return_tarball(req: request, workdir: str, return_filename: str = "sig
     os.unlink(outfile.name)
     return response
 
+def attach_endpoints(app: Sanic):
 
-@app.post("/sign/tegra")
-async def sign_handler_tegra(req: request):
-    f = validate_upload(req, "artifact")
-    if not f:
-        return text("Invalid artifact", status=400)
-    with tempfile.TemporaryDirectory() as workdir:
-        try:
-            s = TegraSigner(workdir, req.form.get("machine"), req.form.get("soctype"), req.form.get("bspversion"))
-        except ValueError:
-            return text("Invalid parameters", status=400)
-
-        if await asyncio.get_running_loop().run_in_executor(None, utils.extract_files, workdir, f):
+    @app.post("/sign/tegra")
+    async def sign_handler_tegra(req: request):
+        f = validate_upload(req, "artifact")
+        if not f:
+            return text("Invalid artifact", status=400)
+        with tempfile.TemporaryDirectory() as workdir:
             try:
-                envvars = parse_manifest(os.path.join(workdir, 'MANIFEST'))
+                s = TegraSigner(workdir, req.form.get("machine"), req.form.get("soctype"), req.form.get("bspversion"))
             except ValueError:
-                return text("Invalid manifest", status=400)
-            if 'BUPGENSPECS' in envvars:
-                result = await asyncio.get_running_loop().run_in_executor(None, s.multisign, envvars)
-            elif 'SIGNFILES' in envvars:
-                result = await asyncio.get_running_loop().run_in_executor(None, s.signfiles, envvars)
+                return text("Invalid parameters", status=400)
+
+            if await asyncio.get_running_loop().run_in_executor(None, utils.extract_files, workdir, f):
+                try:
+                    envvars = parse_manifest(os.path.join(workdir, 'MANIFEST'))
+                except ValueError:
+                    return text("Invalid manifest", status=400)
+                if 'BUPGENSPECS' in envvars:
+                    result = await asyncio.get_running_loop().run_in_executor(None, s.multisign, envvars)
+                elif 'SIGNFILES' in envvars:
+                    result = await asyncio.get_running_loop().run_in_executor(None, s.signfiles, envvars)
+                else:
+                    result = await asyncio.get_running_loop().run_in_executor(None, s.sign, envvars)
+                if result:
+                    return await return_tarball(req, workdir)
+        return text("Signing error", status=500)
+
+
+    @app.post("/sign/imx")
+    async def sign_handler_imx(req: request):
+        csf = validate_upload(req, "csf", ok_types=["text/plain"])
+        if not csf:
+            return text("Invalid CSF", status=400)
+        f = validate_upload(req, "artifact")
+        if not f:
+            return text("Invalid artifact", status=400)
+        with tempfile.TemporaryDirectory() as workdir:
+            try:
+                s = IMXSigner(workdir, req.form.get("machine"), req.form.get("soctype"), req.form.get("cstversion"))
+            except ValueError:
+                return text("Invalid parameters", status=400)
+
+            with open(os.path.join(workdir, "csf-input.txt"), "w") as csfinput:
+                csfinput.write(csf.body.decode('UTF-8'))
+            with open(os.path.join(workdir, "artifact"), "wb") as artifact:
+                artifact.write(f.body)
+
+            outfile = tempfile.NamedTemporaryFile(delete=False)
+            outfile.close()
+
+            if await asyncio.get_running_loop().run_in_executor(None, s.sign, outfile.name):
+                await return_file(req, outfile.name, "artifact.signed")
+                response = None
             else:
-                result = await asyncio.get_running_loop().run_in_executor(None, s.sign, envvars)
-            if result:
-                return await return_tarball(req, workdir)
-    return text("Signing error", status=500)
+                response = text("Signing error", status=500)
+        return response
 
 
-@app.post("/sign/imx")
-async def sign_handler_imx(req: request):
-    csf = validate_upload(req, "csf", ok_types=["text/plain"])
-    if not csf:
-        return text("Invalid CSF", status=400)
-    f = validate_upload(req, "artifact")
-    if not f:
-        return text("Invalid artifact", status=400)
-    with tempfile.TemporaryDirectory() as workdir:
-        try:
-            s = IMXSigner(workdir, req.form.get("machine"), req.form.get("soctype"), req.form.get("cstversion"))
-        except ValueError:
-            return text("Invalid parameters", status=400)
+    @app.post("/sign/modules")
+    async def sign_handler_modules(req: request):
+        f = validate_upload(req, "artifact")
+        if not f:
+            return text("Invalid artifact", status=400)
+        with tempfile.TemporaryDirectory() as workdir:
+            try:
+                s = KernelModuleSigner(workdir, req.form.get("machine"), req.form.get("hashalg", "sha512"))
+            except ValueError:
+                return text("Invalid parameters", status=400)
 
-        with open(os.path.join(workdir, "csf-input.txt"), "w") as csfinput:
-            csfinput.write(csf.body.decode('UTF-8'))
-        with open(os.path.join(workdir, "artifact"), "wb") as artifact:
-            artifact.write(f.body)
-
-        outfile = tempfile.NamedTemporaryFile(delete=False)
-        outfile.close()
-
-        if await asyncio.get_running_loop().run_in_executor(None, s.sign, outfile.name):
-            await return_file(req, outfile.name, "artifact.signed")
-            response = None
-        else:
-            response = text("Signing error", status=500)
-    return response
+            if await asyncio.get_running_loop().run_in_executor(None, utils.extract_files, workdir, f):
+                result = await asyncio.get_running_loop().run_in_executor(None, s.sign)
+                if result:
+                    return await return_tarball(req, workdir)
+        return text("Signing error", status=500)
 
 
-@app.post("/sign/modules")
-async def sign_handler_modules(req: request):
-    f = validate_upload(req, "artifact")
-    if not f:
-        return text("Invalid artifact", status=400)
-    with tempfile.TemporaryDirectory() as workdir:
-        try:
-            s = KernelModuleSigner(workdir, req.form.get("machine"), req.form.get("hashalg", "sha512"))
-        except ValueError:
-            return text("Invalid parameters", status=400)
+    @app.post("/sign/optee")
+    async def sign_handler_optee(req: request):
+        f = validate_upload(req, "artifact")
+        if not f:
+            return text("Invalid artifact", status=400)
+        with tempfile.TemporaryDirectory() as workdir:
+            try:
+                s = OPTEESigner(workdir, req.form.get("machine"))
+            except ValueError:
+                return text("Invalid parameters", status=400)
 
-        if await asyncio.get_running_loop().run_in_executor(None, utils.extract_files, workdir, f):
-            result = await asyncio.get_running_loop().run_in_executor(None, s.sign)
-            if result:
-                return await return_tarball(req, workdir)
-    return text("Signing error", status=500)
-
-
-@app.post("/sign/optee")
-async def sign_handler_optee(req: request):
-    f = validate_upload(req, "artifact")
-    if not f:
-        return text("Invalid artifact", status=400)
-    with tempfile.TemporaryDirectory() as workdir:
-        try:
-            s = OPTEESigner(workdir, req.form.get("machine"))
-        except ValueError:
-            return text("Invalid parameters", status=400)
-
-        if await asyncio.get_running_loop().run_in_executor(None, utils.extract_files, workdir, f):
-            result = await asyncio.get_running_loop().run_in_executor(None, s.sign)
-            if result:
-                return await return_tarball(req, workdir)
-    return text("Signing error", status=500)
+            if await asyncio.get_running_loop().run_in_executor(None, utils.extract_files, workdir, f):
+                result = await asyncio.get_running_loop().run_in_executor(None, s.sign)
+                if result:
+                    return await return_tarball(req, workdir)
+        return text("Signing error", status=500)
 
 
-@app.post("/sign/swupdate")
-async def sign_handler_swupdate(req: request):
-    distro = req.form.get("distro")
-    if not distro:
-        return text("Distro name missing", status=400)
-    method = req.form.get("method")
-    if not method:
-        method = "RSA"
-    f = validate_upload(req, "sw-description")
-    if not f:
-        return text("Invalid sw-description", status=400)
-    with tempfile.TemporaryDirectory() as workdir:
-        try:
-            s = SwupdateSigner(workdir, distro)
-        except ValueError:
-            logger.info("could not init signer")
-            return text("Invalid parameters", status=400)
-        outfile = tempfile.NamedTemporaryFile(delete=False)
-        outfile.close()
-        with open(os.path.join(workdir, "sw-description"), "w") as infile:
-            infile.write(f.body.decode('UTF-8'))
-        if await asyncio.get_running_loop().run_in_executor(None, s.sign,
-                                                            method, "sw-description",
-                                                            outfile.name):
-            await return_file(req, outfile.name, "sw-description.sig")
-            response = None
-        else:
-            response = text("Signing error", status=500)
-    os.unlink(outfile.name)
-    return response
+    @app.post("/sign/swupdate")
+    async def sign_handler_swupdate(req: request):
+        distro = req.form.get("distro")
+        if not distro:
+            return text("Distro name missing", status=400)
+        method = req.form.get("method")
+        if not method:
+            method = "RSA"
+        f = validate_upload(req, "sw-description")
+        if not f:
+            return text("Invalid sw-description", status=400)
+        with tempfile.TemporaryDirectory() as workdir:
+            try:
+                s = SwupdateSigner(workdir, distro)
+            except ValueError:
+                logger.info("could not init signer")
+                return text("Invalid parameters", status=400)
+            outfile = tempfile.NamedTemporaryFile(delete=False)
+            outfile.close()
+            with open(os.path.join(workdir, "sw-description"), "w") as infile:
+                infile.write(f.body.decode('UTF-8'))
+            if await asyncio.get_running_loop().run_in_executor(None, s.sign,
+                                                                method, "sw-description",
+                                                                outfile.name):
+                await return_file(req, outfile.name, "sw-description.sig")
+                response = None
+            else:
+                response = text("Signing error", status=500)
+        os.unlink(outfile.name)
+        return response
 
 
-@app.post("/sign/mender")
-async def sign_handler_mender(req: request):
-    artifact = req.form.get('artifact-uri')
-    if not artifact:
-        return text("Artifact URI missing", status=400)
-    distro = req.form.get('distro')
-    if not distro:
-        return text("Distro name missing", status=400)
-    with tempfile.TemporaryDirectory() as workdir:
-        try:
-            s = MenderSigner(workdir, distro, artifact)
-        except ValueError:
-            return text("Invalid parameters", status=400)
-        if await asyncio.get_running_loop().run_in_executor(None, s.sign):
-            return text("Signing successful")
-    return text("Signing error", status=500)
+    @app.post("/sign/mender")
+    async def sign_handler_mender(req: request):
+        artifact = req.form.get('artifact-uri')
+        if not artifact:
+            return text("Artifact URI missing", status=400)
+        distro = req.form.get('distro')
+        if not distro:
+            return text("Distro name missing", status=400)
+        with tempfile.TemporaryDirectory() as workdir:
+            try:
+                s = MenderSigner(workdir, distro, artifact)
+            except ValueError:
+                return text("Invalid parameters", status=400)
+            if await asyncio.get_running_loop().run_in_executor(None, s.sign):
+                return text("Signing successful")
+        return text("Signing error", status=500)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sanic~=21.12
+sanic>=22.9.0
 cryptography

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ author_email = matt@madison.systems
 [options]
 packages = find:
 install_requires =
-    sanic~=21.12
+    sanic>=22.9.0
     cryptography
 
 [options.entry_points]


### PR DESCRIPTION
- The breakage didn't reveal itself until the default way to invoke subprocesses was changed from 'fork' to 'spawn' in release 22.12.0.

- The solution follows the pattern described in their documentation:

  https://sanic.dev/en/guide/deployment/app-loader.html

- Removing 'app' as a global required retrieval of the app instance from Sanic's app registry in 'config_get'.