### PR TITLE
Updates for version 0.10.0

### DIFF
--- a/digsigserver/keyfiles.py
+++ b/digsigserver/keyfiles.py
@@ -1,17 +1,17 @@
 import tempfile
 import os
 
-from . import server
+from sanic import Sanic
 from . import utils
 
 
 class KeyFiles:
     signing_types = ['tegrasign', 'imxsign', 'kmodsign', 'mender', 'swupdate', 'opteesign']
 
-    def __init__(self, signtype: str, machine_or_distro: str):
+    def __init__(self, app: Sanic, signtype: str, machine_or_distro: str):
         if signtype not in self.signing_types:
             raise RuntimeError('unrecognized signing type: {}'.format(signtype))
-        self.keyfileuri = '{}/{}/{}/'.format(server.config_get('KEYFILE_URI'),
+        self.keyfileuri = '{}/{}/{}/'.format(app.config.get('KEYFILE_URI'),
                                              machine_or_distro, signtype)
         self.tmpdir = None
         if not utils.uri_exists(self.keyfileuri, is_dir=True):

--- a/digsigserver/signers/kmodsign.py
+++ b/digsigserver/signers/kmodsign.py
@@ -1,13 +1,14 @@
 import os
 import re
 from digsigserver.signers import Signer
+from sanic import Sanic
 
 
 class KernelModuleSigner(Signer):
 
     keytag = 'kmodsign'
 
-    def __init__(self, workdir: str, machine: str, hashalg: str):
+    def __init__(self, app: Sanic, workdir: str, machine: str, hashalg: str):
         signcmd = os.path.join('/usr', 'src', 'linux-headers-{}'.format(os.uname().release),
                                'scripts', 'sign-file')
         if not os.path.exists(signcmd):
@@ -16,7 +17,7 @@ class KernelModuleSigner(Signer):
         if not re.match(r'sha(256|384|512)$', hashalg):
             raise ValueError('unrecognized hash algorithm: {}'.format(hashalg))
         self.hashalg = hashalg
-        super().__init__(workdir, machine)
+        super().__init__(app, workdir, machine)
 
     def sign(self) -> bool:
         privkey = self.keys.get('kernel-signkey.priv')

--- a/digsigserver/signers/mendersign.py
+++ b/digsigserver/signers/mendersign.py
@@ -2,13 +2,14 @@ import os
 import shutil
 from digsigserver.signers import Signer
 from digsigserver import utils
+from sanic import Sanic
 
 
 class MenderSigner(Signer):
 
     keytag = 'mender'
 
-    def __init__(self, workdir: str, distro: str, artifact_uri: str):
+    def __init__(self, app: Sanic, workdir: str, distro: str, artifact_uri: str):
         signcmd = shutil.which('mender-artifact')
         if not signcmd:
             raise RuntimeError('no mender-artifact command')
@@ -16,7 +17,7 @@ class MenderSigner(Signer):
         if not utils.uri_exists(artifact_uri):
             raise RuntimeError('cannot access artifact {}'.format(artifact_uri))
         self.artifact_uri = artifact_uri
-        super().__init__(workdir, distro)
+        super().__init__(app, workdir, distro)
 
     def sign(self) -> bool:
         privkey = self.keys.get('private.key')

--- a/digsigserver/signers/opteesign.py
+++ b/digsigserver/signers/opteesign.py
@@ -10,6 +10,7 @@ from uuid import UUID
 import struct
 import math
 
+from sanic import Sanic
 from sanic.log import logger
 
 SHDR_BOOTSTRAP_TA = 1
@@ -61,10 +62,10 @@ class OPTEESigner (Signer):
 
     keytag = 'opteesign'
 
-    def __init__(self, workdir: str, machine: str):
+    def __init__(self, app: Sanic, workdir: str, machine: str):
         logger.debug("machine: {}".format(machine))
         self.machine = machine
-        super().__init__(workdir, machine)
+        super().__init__(app, workdir, machine)
 
     def sign(self) -> bool:
         keyfile = self.keys.get('optee-signing-key.pem')

--- a/digsigserver/signers/opteesign.py
+++ b/digsigserver/signers/opteesign.py
@@ -1,6 +1,5 @@
 import os
 from digsigserver.signers import Signer
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
@@ -25,7 +24,7 @@ algorithms = {'TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA256': 0x70414930,
 def _sign_ta(img: bytes, dirpath: str, uuid: str,
              ta_version: str, key: rsa.RSAPrivateKey) -> bool:
     chosen_hash = hashes.SHA256()
-    h = hashes.Hash(chosen_hash, default_backend())
+    h = hashes.Hash(chosen_hash)
 
     digest_len = chosen_hash.digest_size
     sig_len = math.ceil(key.key_size / 8)
@@ -72,7 +71,7 @@ class OPTEESigner (Signer):
         with open(keyfile, 'rb') as f:
             data = f.read()
             try:
-                key = serialization.load_pem_private_key(data, password=None, backend=default_backend())
+                key = serialization.load_pem_private_key(data, password=None)
             except ValueError:
                 logger.error("could not parse RSA private key")
                 self.keys.cleanup()

--- a/digsigserver/signers/signer.py
+++ b/digsigserver/signers/signer.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 from typing import Optional
 from digsigserver.keyfiles import KeyFiles
+from sanic import Sanic
 from sanic.log import logger
 
 
@@ -9,9 +10,10 @@ class Signer:
 
     keytag = 'Unknown'
 
-    def __init__(self, workdir: str, key_selector: str):
+    def __init__(self, app: Sanic, workdir: str, key_selector: str):
+        self.app = app
         self.workdir = workdir
-        self.keys = KeyFiles(self.keytag, key_selector)
+        self.keys = KeyFiles(app, self.keytag, key_selector)
 
     def sign(self, *args) -> bool:
         raise RuntimeError("unimplemented sign method")

--- a/digsigserver/signers/swupdsign.py
+++ b/digsigserver/signers/swupdsign.py
@@ -1,17 +1,17 @@
 import shutil
 from digsigserver.signers import Signer
+from sanic import Sanic
 
 
 class SwupdateSigner(Signer):
-
     keytag = 'swupdate'
 
-    def __init__(self, workdir: str, distro: str):
+    def __init__(self, app: Sanic, workdir: str, distro: str):
         signcmd = shutil.which('openssl')
         if not signcmd:
             raise RuntimeError('no openssl command')
         self.signcmd = signcmd
-        super().__init__(workdir, distro)
+        super().__init__(app, workdir, distro)
 
     def sign(self, method: str, sw_description: str, outfile: str) -> bool:
         if method == "RSA":

--- a/digsigserver/test.py
+++ b/digsigserver/test.py
@@ -1,4 +1,9 @@
+from sanic import Sanic
+from sanic.worker.loader import AppLoader
 from digsigserver import server
 
 if __name__ == "__main__":
-    server.app.run(host="127.0.0.1", port=8888, debug=True)
+    loader = AppLoader(factory=server.create_app)
+    app = loader.load()
+    app.prepare(host="127.0.0.1", port=8888, debug=True)
+    Sanic.serve(primary=app, app_loader=loader)

--- a/doc/imxsign.md
+++ b/doc/imxsign.md
@@ -1,0 +1,65 @@
+# Bootloader signing for NXP i.MX SoCs
+
+## Prerequisites
+For signing i.MX bootloader/kernel images, you must obtain the NXP code signing tool (CST)
+from the [NXP web site](https://www.nxp.com), and unpack them under `/opt/NXP`. For example,
+using version 3.3.1 of CST:
+
+    $ sudo mkdir -p /opt/NXP
+	$ sudo tar -C /opt/NXP -x -f cst-3.3.1.tgz
+
+You can use a different top-level path than `/opt/NXP` by setting the environment
+variable `DIGSIGSERVER_IMX_CST_BASE`. Multiple versions of CST are supported; the client
+includes the needed version in its request.
+
+## Configuration variable
+**DIGSIGSERVER_IMX_CST_BASE**: path to the directory under which the NXP CST tools
+have been installed.  Defaults to `/opt/NXP`.
+
+## Keyfile storage layout
+For i.MX signing, the necessary keys and certificates are expected to be present in
+a tarball named `imx-cst-keys.tar.gz`:
+
+    ${DIGSIGSERVER_KEYFILE_URI}/${machine}/imxsign/imx-cst-keys.tar.gz
+
+where `${machine}` is the value of the `machine=` parameter included in the signing request.
+The tarball is expected to include the private keys, certificates, and SRK table file used by
+the `cst` tool to perform the signing. If you use the default PKI generation scripts that
+NXP provides in the CST package, this would likely include:
+
+    keys/IMG*.pem
+	keys/CSF*.pem
+	keys/key_pass.txt
+	crts/IMG*.pem
+	crts/CSF*.pem
+	crts/SRK*table.bin
+
+although the actual contents could vary depending on the number of keys/certs you decided
+to create. The tarball is extracted to the server's temporary working directory during
+signing.  The certificate path names must match exactly those included in the CSF description
+file sent by the client, so using relative path names (or using a flat directory structure,
+if desired) is recommended. Note that the `cst` tool itself assumes that the private key
+assoicated with a certificate either resides in the same directory as the certificate (with
+the filename stem ending with `key` instead of `crt`), or, if the certificate has `crts`
+in the path, a parallel directory called `keys` (along with the `crt` -> `key` remapping
+in the filename).
+
+## REST API endpoint
+
+Request type: `POST`
+
+Endpoint: `/sign/imx`
+
+Expected parameters:
+* `machine=<machine-name>` - a name for the device, used to locate the signing keys
+* `soctype=<soctype>` - currently only `mx8m` recognized (but not currently used)
+* `cstversion=<cst-version>` - the version of CST (e.g., `3.3.1`)
+* `csf=<body>` - plain/text CSF description file
+* `artifact=<body>` - binary associated with the CSF description file
+
+Response: binary CSF blob containing the signing commands, signature hashes, and certificates
+
+The client is responsible for inserting/appending the CSF blob (and an IVT) at the
+correct location in the binary for use on the target device.
+
+Example client: TBD

--- a/doc/kmodsign.md
+++ b/doc/kmodsign.md
@@ -1,0 +1,34 @@
+# Kernel module signing
+
+This can be used for signing kernel modules with a fixed key, rather than using a
+randomly-generated keypair at build time, for when a modules are built/deployed
+separately.
+
+## Prerequisites
+For kernel module signing, your Linux distribution must have the `sign-file` tool
+at `/usr/src/linux-headers-$(uname -r)/scripts/sign-file`, and that version of the
+tool must be compatible with the kernel you are cross-building.
+
+## Key file layout
+For kernel module signing, the private and public keys for signing the kernel modules 
+are expected to be at:
+
+    ${DIGSIGSERVER_KEYFILE_URI}/${machine}/kmodsign/kernel-signkey.priv
+    ${DIGSIGSERVER_KEYFILE_URI}/${machine}/kmodsign/kernel-signkey.x509
+
+where `${machine}` is the value of the `machine=` parameter included in the signing request.
+
+## REST API Endpoint
+
+Request type: `POST`
+
+Endpoint: `/sign/modules`
+
+Expected parameters:
+* `machine=<machine>` - a name for the device, used to locate the signing keys
+* `hashalg=<algname>` (optional) - the hash algorithm to be used, defaults to `sha512`
+* `artifact=<body>` - gzip-compressed tarball containing the tree of modules to be signed
+
+Response: gzip-compressed tarball containing the same tree of modules, signed
+
+Example client: [kernel-module-signing.bbclass](https://github.com/madisongh/tegra-test-distro/blob/master/layers/meta-testdistro/classes/kernel-module-signing.bbclass)

--- a/doc/mendersign.md
+++ b/doc/mendersign.md
@@ -1,0 +1,35 @@
+# Mender artifact signing
+
+## Prerequisites
+For Mender artifact signing, you must have the `mender-artifact` tool available
+in the PATH.  Visit [the Mender documentation pages](https://docs.mender.io) and
+go to the "Downloads" section to find a download of a pre-built copy of this tool,
+or follow the instructions there for building it from source.  Installing it in
+`/usr/local/bin` should make it available.
+
+## Key file storage layout
+For Mender artifacts, the signing key is expected to be at
+
+    ${DIGSIGSERVER_KEYFILE_URI}/${distro}/mender/private.key
+
+where `${distro}` is the value of the `distro=` parameter included in the signing request.
+
+## REST API endpoint
+
+Request type: `POST`
+
+Endpoint: `/sign/mender`
+
+Expected parameters:
+* `distro=<distro>` - a name for the "distro", used to locate the signing keys
+* `artifact-uri=<url>` - a URL that `digsigserver` can use to download the Mender artifact
+
+Because Mender full-image artifacts are often hundreds of megabytes or larger, the artifact
+itself is **not** posted in the body of the request.  Instead, a URL is provided (currently
+only supporting `file://` and `s3://` URLs).  The client must upload the artifact to the
+specified location. `digsigserver` will download it, apply the signature, then upload
+the signed copy back to the same location.
+
+Response: no body, just a status code
+
+Example client: [mendersign.bbclass](https://github.com/madisongh/tegra-test-distro/blob/master/layers/meta-testdistro/classes/mendersign.bbclass)

--- a/doc/opteesign.md
+++ b/doc/opteesign.md
@@ -1,0 +1,34 @@
+# Signing OP-TEE Trusted Applications
+
+This signer implements a subset of the functions in the `sign-encrypt.py` script
+from the OP-TEE OS build environment.  Only signing is supported (no encryption),
+and only a single signing algorithm is supported.
+
+## Prerequisites
+The OP-TEE TA signer directly calls on functions in the Python `cryptography`
+package - in particular, functions in the "Hazardous Materials" section of
+that package. The `cryptography` package has changed frequently over its history
+and has complicated dependencies on underlying crypto library packages, so
+be careful.
+
+## Key file storage layout
+For signing OP-TEE trusted applications, the private key for signing TAs is expected
+to be at:
+
+    ${DIGSIGSERVER_KEYFILE_URI}/${machine}/opteesign/optee-signing-key.pem
+
+where `${machine}` is the value of the `machine=` parameter included in the signing request.
+
+## REST API endpoint
+
+Request type: `POST`
+
+Endpoint: `/sign/optee`
+
+Expected parameters:
+* `machine=<machine>` - a name for the device, used to locate the signing keys
+* `artifact=<body>` - gzip-compressed tarball containing a tree of `<uuid>.stripped-elf` and `<uuid>.ta-version` files
+
+Response: gzip-compressed tarball containing the signed `<uuid>.ta` files
+
+Example client: TBD

--- a/doc/swupdsign.md
+++ b/doc/swupdsign.md
@@ -1,0 +1,35 @@
+# Signing swupdate packages
+
+Provides a signer for the `sw-description` used in swupdate packages.
+
+## Prerequisites
+For signing `sw-description` files for swupdate packages, `openssl` is required.
+RSA and CMS signing methods are supported.
+
+## Key file storage layout
+For SWUpdate, the signing key is expected to be at
+
+for RSA:
+
+    ${DIGSIGSERVER_KEYFILE_URI}/${distro}/swupdate/rsa-private.key
+
+For CMS:
+
+    ${DIGSIGSERVER_KEYFILE_URI}/${distro}/swupdate/cms.cert
+    ${DIGSIGSERVER_KEYFILE_URI}/${distro}/swupdate/cms-private.key
+
+where `${distro}` is the value of the `distro=` parameter included in the signing request.
+
+## REST API endpoint
+
+Request type: `POST`
+
+Endpoint: `/sign/swupdate`
+
+Expected parameters:
+* `distro=<distro>` - a name for the "distro", used to locate the signing keys
+* `sw-description=<body>` - the contents of the `sw-description` file to have signatures included
+
+Response: a `sw-description` file with signatures inserted
+
+Example client: [swupdatesign.bbclass](https://github.com/madisongh/tegra-test-distro/blob/master/layers/meta-testdistro/classes/swupdatesign.bbclass)

--- a/doc/tegrasign.md
+++ b/doc/tegrasign.md
@@ -1,0 +1,110 @@
+# Tegra signing
+
+Supports signing of the bootloader, kernel, DTB, firmware, etc. needed for supporting
+secure boot on NVIDIA Jetson modules.
+
+**NOTE:** The signer currently supports the R32.x series of Jetson Linux (L4T) releases.
+Support for later versions (R35.x and above) and Orin (Tegra234) modules is pending.
+
+## Prerequsities
+For Jetson bootloader signing, you must download the BSP and
+secure boot packages for the specific version of Jetson Linux you are using
+from [NVIDIA's L4T download site](https://developer.nvidia.com/embedded/jetson-linux-archive).
+Unpack the two tarballs into a specific location in the filesystem
+based on the version and target architecture of the BSP, so they can be found
+by the server.  For example, for L4T R32.4.3 for Jetson TX2/Xavier, you would enter:
+
+    $ sudo mkdir -p /opt/nvidia/L4T-32.4.3-tegra186
+    $ sudo tar -C /opt/nvidia/L4T-32.4.3-tegra186 -xf Tegra186_Linux_R32.4.3_aarch64.tbz2
+    $ sudo tar -C /opt/nvidia/L4T-32.4.3-tegra186 -xf secureboot_R32.4.3_aarch64.tbz2
+
+You can use a different top-level path than `/opt/nvidia` by setting the environment
+variable `DIGSIGSERVER_L4T_TOOLS_BASE`. The top-level directory under that base path
+must, however, always be `L4T-<version>-<tegraXXX>`, where `version` is the BSP
+version (without the "R" prefix) and `tegraXXX` is either `tegra186` for TX2/Xavier or
+`tegra210` for TX1/Nano. The server supports having multiple versions of the BSP
+installed.
+
+For each BSP version/architecture, you also need a helper script (and possibly one or more
+patches to apply to NVIDIA's scripts), available from the
+[meta-tegra repository](https://github.com/OE4T/meta-tegra).
+
+For L4T R32.4.3, checkout the **dunfell-l4t-r32.4.3** branch of that repository. The helper scripts
+are at `recipes-bsp/tegra-binaries/tegra-helper-scripts/tegraXXX-flash-helper.sh`. The
+needed script(s) should get installed without the `.sh` suffix into the `bootloader`
+directory for the BSP.  For example (for R32.4.3, TX2/Xavier):
+
+    $ cd /path/to/meta-tegra/recipes-bsp/tegra-binaries/tegra-helper-scripts
+    $ sudo install -m 0755 tegra186-flash-helper.sh \
+      /opt/nvidia/L4T-32.4.3-tegra186/Linux_for_Tegra/bootloader/tegra186-flash-helper
+    $ sudo install -m 0755 tegra194-flash-helper.sh \
+      /opt/nvidia/L4T-32.4.3-tegra186/Linux_for_Tegra/bootloader/tegra194-flash-helper
+
+If you are supporting Jetson TX2 or Jetson AGX Xavier devices that use both PKC
+signing and SBK encryption of bootloader files, you will also need to apply at
+least this patch from meta-tegra:
+
+    $ P=/path/to/meta-tegra/recipes-bsp/tegra-binaries/files
+    $ cd /opt/nvidia/L4T-32.4.3-tegra186/Linux_for_Tegra
+    $ sudo patch -p1 < $P/0002-Fix-typo-in-l4t_bup_gen.func.patch
+
+Check the `tegraXXX-flashtools-native` recipes in meta-tegra to see if
+other patches might also be needed.
+
+### Python version requirements and installation paths
+Some of the Python scripts included in the L4T BSP are written in Python 2, and assume
+that `/usr/bin/python` invokes the Python 2 interpreter.  The signer attempts to work around
+that assumption (which can be problematic for more modern distros) by wrapping such
+scripts to invoke the Python 2 interpreter through the `python2` command. You **must** still
+have Python 2 installed, however, for Tegra signing.
+
+Depending on the BSP version you are using, some of the Python 3 scripts in the BSP package
+may not be compatible with more recent versions of Python 3 (such as 3.9 or later).  You should
+find patches for those scripts in the [meta-tegra repository](https://github.com/OE4T/meta-tegra)
+repository.  (Do **not**, however, apply any patches that convert the Python 2 scripts to
+Python 3.)
+
+## Configuration variable
+
+**DIGSIGSERVER_L4T_TOOLS_BASE**: path to the directory under which the L4T BSP package(s)
+have been installed.  Defaults to `/opt/nvidia`.
+
+## Key file storage layout
+For Jetson bootloader signing, the following files are expected to be present:
+
+    ${DIGSIGSERVER_KEYFILE_URI}/${machine}/tegrasign/rsa_priv.pem
+    ${DIGSIGSERVER_KEYFILE_URI}/${machine}/tegrasign/sbk.txt
+
+where `${machine}` is the value of the `machine=` parameter included in the signing request.
+The `rsa_priv.pem` file is the PKC private key for signing. It **must** be present.
+The `sbk.txt` file is the SBK encryption key.  It is optional, and only need be included
+if your device has had an SBK burned into its secure boot fuses.
+
+For later versions of L4T that support encryption of the kernel, kernel DTB, and XUSB firmware
+when using  NVIDIA's `hwkey-sample` trusted application on T186/T194 platforms, you should
+also provide  the "user key" that you created at:
+
+    ${DIGSIGSERVER_KEYFILE_URI}/${machine}/tegrasign/user_key.txt
+
+This file is not required, and if you are not using NVIDIA's trusted applications, and/or
+you have modified the bootloader to perform only signature checks (as opposed to signature
+checks and decryption), you should omit this particular key file.
+
+## REST API endpoint
+
+Request type: `POST`
+
+Endpoint: `/sign/tegra`
+
+Expected parameters:
+* `machine=<machine-name>` - a name for the device, used to locate the signing keys
+* `soctype=<soctype>` - one of `tegra186`, `tegra194`, `tegra210`
+* `bspversion=<l4t-version>` - the L4T BSP version, e.g. `32.4.3`
+* `artifact=<body>` - gzip-compressed tarball containing the binaries to be signed
+
+The artifact tarball must also include a `MANIFEST` file with additional
+information about the hardware and contents of the tarball.
+
+Response: gzip-compressed tarball containing the signed binaries
+
+Example client: [tegrasign.bbclass](https://github.com/madisongh/tegra-test-distro/blob/master/layers/meta-testdistro/classes/tegrasign.bbclass)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 sanic>=22.9.0
-cryptography
+cryptography>=3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = digsigserver
-version = 0.9.2
+version = 0.10.0
 license = MIT
 license_files = LICENSE
 author = Matt Madison
@@ -10,7 +10,7 @@ author_email = matt@madison.systems
 packages = find:
 install_requires =
     sanic>=22.9.0
-    cryptography
+    cryptography>=3.1
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
* Moved per-signer documentation out of README to separate files
* Eliminated the `server.config_get` function by adding an `app` object reference to constructors that need config variables
* Minor cleanup of `cryptography` use in the OP-TEE signer