### PR TITLE
Generate and Sign EKB

### DIFF
--- a/digsigserver/keyfiles.py
+++ b/digsigserver/keyfiles.py
@@ -16,7 +16,8 @@ class KeyFiles:
         'rksign',
         'rkopteesign',
         'uefisign',
-        'ueficapsulesign'
+        'ueficapsulesign',
+        'ekbsign'
     ]
 
     def __init__(self, app: Sanic, signtype: str, machine_or_distro: str):

--- a/digsigserver/server.py
+++ b/digsigserver/server.py
@@ -237,6 +237,7 @@ def attach_endpoints(app: Sanic):
                 response = None
             else:
                 response = text("Signing error", status=500)
+        os.unlink(outfile.name)
         return response
 
     @app.post("/sign/tegra/ueficapsule")
@@ -268,6 +269,7 @@ def attach_endpoints(app: Sanic):
                 response = None
             else:
                 response = text("Signing error", status=500)
+        os.unlink(outfile.name)
         return response
 
     @app.post("/sign/optee")

--- a/digsigserver/signers/ekbsign.py
+++ b/digsigserver/signers/ekbsign.py
@@ -1,0 +1,39 @@
+import os
+
+from digsigserver.signers import Signer
+
+from sanic import Sanic
+from sanic.log import logger
+
+
+class EKBSigner (Signer):
+
+    keytag = 'ekbsign'
+
+    def __init__(self, app: Sanic, workdir: str, machine: str, soctype: str, bspversion: str):
+        logger.debug('machine: {}, soctype: {}, bspversion: {}'.format(machine, soctype, bspversion))
+        if soctype not in ['tegra194', 'tegra234']:
+            raise ValueError("soctype '{}' invalid".format(soctype))
+        self.toolspath = os.path.join(app.config.get('L4T_TOOLS_BASE'),
+                                      'L4T-{}-{}'.format(bspversion, 'tegra186' if soctype == 'tegra194' else soctype),
+                                      'Linux_for_Tegra')
+        if not os.path.exists(self.toolspath):
+            raise ValueError('no tools available for soctype={} bspversion={}'.format(soctype, bspversion))
+        self.soctype = soctype
+        super().__init__(app, workdir, machine)
+
+    def generate_ekb(self, outfile: str) -> bool:
+        oem_k1_key = self.keys.get('oem_k1.key')
+        fixed_vector = self.keys.get('fixed-vector')
+        uefi_variable_authentication_key = self.keys.get('uefi-variable-authentication.key')
+        cmd = [
+            'python3', self.toolspath + '/source/public/optee/samples/hwkey-agent/host/tool/gen_ekb/gen_ekb.py',
+            '-chip', 't234' if self.soctype == 'tegra234' else 't194',
+            '-oem_k1_key', oem_k1_key,
+            '-fv', fixed_vector,
+            '-in_auth_key', uefi_variable_authentication_key,
+            '-out', outfile
+        ]
+        result = self.run_command(cmd)
+
+        return result

--- a/digsigserver/signers/tegrasign.py
+++ b/digsigserver/signers/tegrasign.py
@@ -31,6 +31,7 @@ class TegraSigner (Signer):
                      os.path.join('bootloader', 't234.py'),
                      os.path.join('bootloader', 'ed25519.py'),
                      os.path.join('bootloader', 'tegrasign_v3_hsm.py'),
+                     os.path.join('bootloader', 'tegrasign_v3_oemkey.yaml'),
                      os.path.join('bootloader', 'tegraopenssl'),
                      os.path.join('bootloader', 'pyfdt')]
 

--- a/digsigserver/signers/tegrasign.py
+++ b/digsigserver/signers/tegrasign.py
@@ -63,6 +63,7 @@ class TegraSigner (Signer):
             if bspmajor > 32 or (bspmajor == 32 and bspminor >= 6):
                 self.scripts.append(os.path.join('bootloader', 'nvflashxmlparse'))
         else:
+            self.scripts.append(os.path.join('bootloader', 'nvflashxmlparse'))
             self.scripts.append(os.path.join('bootloader', 'rollback', 'rollback_parser.py'))
             if bspmajor == 32 and (bspminor > 7 or (bspminor == 7 and bspmaint >= 4)):
                 self.scripts.append(os.path.join('bootloader', 'rewrite-tegraflash-args'))

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
 FROM l4t-release:32.5.2 AS l4t-32.5.2
 FROM l4t-release:32.7.4 AS l4t-32.7.4
 FROM l4t-release:35.4.1 AS l4t-35.4.1
+FROM l4t-release:35.5.0 AS l4t-35.5.0
 
 FROM ubuntu:18.04
 
@@ -30,6 +31,7 @@ WORKDIR ${DIGSIGSERVER}
 COPY --from=l4t-32.5.2 /opt/nvidia /opt/nvidia
 COPY --from=l4t-32.7.4 /opt/nvidia /opt/nvidia
 COPY --from=l4t-35.4.1 /opt/nvidia /opt/nvidia
+COPY --from=l4t-35.5.0 /opt/nvidia /opt/nvidia
 
 COPY digsigserver ${DIGSIGSERVER}/digsigserver
 COPY requirements.txt ${DIGSIGSERVER}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,10 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1
 
 RUN pip3 install --upgrade pip
 
-RUN pip3 install PyYAML
+RUN pip3 install \
+  PyYAML \
+  cryptograpy \
+  pycryptodome
 
 ENV DIGSIGSERVER=/digsigserver
 ENV DIGSIGSERVER_KEYFILE_URI=${DIGSIGSERVER}

--- a/docker/Dockerfile.l4t-32.5.2
+++ b/docker/Dockerfile.l4t-32.5.2
@@ -29,7 +29,8 @@ ARG TEGRA186_32_5_2_DIR=/opt/nvidia/L4T-32.5.2-tegra186/Linux_for_Tegra
 RUN cd meta-tegra-dunfell-l4t-r32.5.0/recipes-bsp/tegra-binaries/tegra-helper-scripts && \
     install -m 0755 tegra210-flash-helper.sh ${TEGRA210_32_5_2_DIR}/bootloader/tegra210-flash-helper && \
     install -m 0755 tegra194-flash-helper.sh ${TEGRA186_32_5_2_DIR}/bootloader/tegra194-flash-helper && \
-    install -m 0755 nvflashxmlparse.py ${TEGRA210_32_5_2_DIR}/bootloader/nvflashxmlparse
+    install -m 0755 nvflashxmlparse.py ${TEGRA210_32_5_2_DIR}/bootloader/nvflashxmlparse && \
+    install -m 0755 nvflashxmlparse.py ${TEGRA186_32_5_2_DIR}/bootloader/nvflashxmlparse
 
 RUN cd meta-tegra-dunfell/recipes-bsp/tegra-binaries/tegra-helper-scripts && \
     install -m 0755 tegra-signimage-helper.sh ${TEGRA210_32_5_2_DIR}/tegra-signimage-helper && \

--- a/docker/Dockerfile.l4t-32.7.4
+++ b/docker/Dockerfile.l4t-32.7.4
@@ -27,7 +27,8 @@ RUN cd meta-tegra-dunfell/recipes-bsp/tegra-binaries/tegra-helper-scripts && \
     install -m 0755 tegra194-flash-helper.sh ${TEGRA186_32_7_4_DIR}/bootloader/tegra194-flash-helper && \
     install -m 0755 tegra-signimage-helper.sh ${TEGRA210_32_7_4_DIR}/tegra-signimage-helper && \
     install -m 0755 tegra-signimage-helper.sh ${TEGRA186_32_7_4_DIR}/tegra-signimage-helper && \
-    install -m 0755 nvflashxmlparse.py ${TEGRA210_32_7_4_DIR}/bootloader/nvflashxmlparse
+    install -m 0755 nvflashxmlparse.py ${TEGRA210_32_7_4_DIR}/bootloader/nvflashxmlparse && \
+    install -m 0755 nvflashxmlparse.py ${TEGRA186_32_7_4_DIR}/bootloader/nvflashxmlparse
 
 RUN patch -p1 --directory=${TEGRA210_32_7_4_DIR} < meta-tegra-dunfell/recipes-bsp/tegra-binaries/files/0013-Fix-location-of-bsp_version-file-in-l4t_bup_gen.func.patch
 RUN patch -p1 --directory=${TEGRA186_32_7_4_DIR} < meta-tegra-dunfell/recipes-bsp/tegra-binaries/files/0013-Fix-location-of-bsp_version-file-in-l4t_bup_gen.func.patch

--- a/docker/Dockerfile.l4t-35.4.1
+++ b/docker/Dockerfile.l4t-35.4.1
@@ -5,7 +5,8 @@ RUN apt-get update && apt-get install -y \
   wget \
   && rm -rf /var/lib/apt/lists/*
 
-RUN git clone --branch kirkstone https://github.com/OE4T/meta-tegra.git meta-tegra-kirkstone
+RUN git clone --branch kirkstone https://github.com/OE4T/meta-tegra.git meta-tegra-kirkstone \
+&& cd meta-tegra-kirkstone && git checkout -b new_branch f8cb5c6ad2617755f5cb74f85a1b0b2cd6380f6c
 
 RUN mkdir -p /opt/nvidia/L4T-35.4.1-tegra234
 RUN wget -q -O - https://developer.nvidia.com/downloads/embedded/l4t/r35_release_v4.1/release/jetson_linux_r35.4.1_aarch64.tbz2 | \

--- a/docker/Dockerfile.l4t-35.4.1
+++ b/docker/Dockerfile.l4t-35.4.1
@@ -23,7 +23,9 @@ RUN cd meta-tegra-kirkstone/recipes-bsp/tegra-binaries/tegra-helper-scripts && \
     install -m 0755 tegra234-flash-helper.sh ${TEGRA234_35_4_1_DIR}/bootloader/tegra234-flash-helper && \
     install -m 0755 tegra194-flash-helper.sh ${TEGRA186_35_4_1_DIR}/bootloader/tegra194-flash-helper && \
     install -m 0755 tegra-signimage-helper.sh ${TEGRA234_35_4_1_DIR}/tegra-signimage-helper && \
-    install -m 0755 tegra-signimage-helper.sh ${TEGRA186_35_4_1_DIR}/tegra-signimage-helper
+    install -m 0755 tegra-signimage-helper.sh ${TEGRA186_35_4_1_DIR}/tegra-signimage-helper && \
+    install -m 0755 nvflashxmlparse.py ${TEGRA234_35_4_1_DIR}/bootloader/nvflashxmlparse && \
+    install -m 0755 nvflashxmlparse.py ${TEGRA186_35_4_1_DIR}/bootloader/nvflashxmlparse
 
 RUN patch -p1 --directory=${TEGRA234_35_4_1_DIR} < meta-tegra-kirkstone/recipes-bsp/tegra-binaries/files/0013-Fix-location-of-bsp_version-file-in-l4t_bup_gen.func.patch
 RUN patch -p1 --directory=${TEGRA234_35_4_1_DIR} < meta-tegra-kirkstone/recipes-bsp/tegra-binaries/files/0014-odmsign.func-fix-ODMDATA-and-overlay-DTB-handling-fo.patch

--- a/docker/Dockerfile.l4t-35.5.0
+++ b/docker/Dockerfile.l4t-35.5.0
@@ -1,0 +1,48 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y \
+  git \
+  python3-cryptography \
+  wget \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --branch kirkstone https://github.com/OE4T/meta-tegra.git meta-tegra-kirkstone
+
+RUN mkdir -p /opt/nvidia/L4T-35.5.0-tegra234 && \
+    mkdir -p /opt/nvidia/L4T-35.5.0-tegra186
+
+RUN wget -q -O /opt/nvidia/l4t-release.tbz2 https://developer.nvidia.com/downloads/embedded/l4t/r35_release_v5.0/release/jetson_linux_r35.5.0_aarch64.tbz2
+
+RUN tar -xjf /opt/nvidia/l4t-release.tbz2 -C /opt/nvidia/L4T-35.5.0-tegra234 && \
+    tar -xjf /opt/nvidia/l4t-release.tbz2 -C /opt/nvidia/L4T-35.5.0-tegra186
+
+RUN rm /opt/nvidia/l4t-release.tbz2
+
+RUN wget -q -O /opt/nvidia/public_sources.tbz2 https://developer.nvidia.com/downloads/embedded/l4t/r35_release_v5.0/sources/public_sources.tbz2
+
+RUN tar -xjf /opt/nvidia/public_sources.tbz2 -C /opt/nvidia/L4T-35.5.0-tegra234 Linux_for_Tegra/source/public/nvidia-jetson-optee-source.tbz2 && \
+    tar -xjf /opt/nvidia/L4T-35.5.0-tegra234/Linux_for_Tegra/source/public/nvidia-jetson-optee-source.tbz2 -C /opt/nvidia/L4T-35.5.0-tegra234/Linux_for_Tegra/source/public
+
+RUN tar -xjf /opt/nvidia/public_sources.tbz2 -C /opt/nvidia/L4T-35.5.0-tegra186 Linux_for_Tegra/source/public/nvidia-jetson-optee-source.tbz2 && \
+    tar -xjf /opt/nvidia/L4T-35.5.0-tegra186/Linux_for_Tegra/source/public/nvidia-jetson-optee-source.tbz2 -C /opt/nvidia/L4T-35.5.0-tegra186/Linux_for_Tegra/source/public
+
+RUN rm /opt/nvidia/public_sources.tbz2 && \
+    rm /opt/nvidia/L4T-35.5.0-tegra234/Linux_for_Tegra/source/public/nvidia-jetson-optee-source.tbz2 && \
+    rm /opt/nvidia/L4T-35.5.0-tegra186/Linux_for_Tegra/source/public/nvidia-jetson-optee-source.tbz2
+
+ARG TEGRA234_35_5_0_DIR=/opt/nvidia/L4T-35.5.0-tegra234/Linux_for_Tegra
+ARG TEGRA186_35_5_0_DIR=/opt/nvidia/L4T-35.5.0-tegra186/Linux_for_Tegra
+
+RUN cd meta-tegra-kirkstone/recipes-bsp/tegra-binaries/tegra-helper-scripts && \
+    install -m 0755 tegra234-flash-helper.sh ${TEGRA234_35_5_0_DIR}/bootloader/tegra234-flash-helper && \
+    install -m 0755 tegra194-flash-helper.sh ${TEGRA186_35_5_0_DIR}/bootloader/tegra194-flash-helper && \
+    install -m 0755 tegra-signimage-helper.sh ${TEGRA234_35_5_0_DIR}/tegra-signimage-helper && \
+    install -m 0755 tegra-signimage-helper.sh ${TEGRA186_35_5_0_DIR}/tegra-signimage-helper && \
+    install -m 0755 nvflashxmlparse.py ${TEGRA234_35_5_0_DIR}/bootloader/nvflashxmlparse && \
+    install -m 0755 nvflashxmlparse.py ${TEGRA186_35_5_0_DIR}/bootloader/nvflashxmlparse
+
+RUN patch -p1 --directory=${TEGRA234_35_5_0_DIR} < meta-tegra-kirkstone/recipes-bsp/tegra-binaries/files/0013-Fix-location-of-bsp_version-file-in-l4t_bup_gen.func.patch
+RUN patch -p1 --directory=${TEGRA234_35_5_0_DIR} < meta-tegra-kirkstone/recipes-bsp/tegra-binaries/files/0014-odmsign.func-fix-ODMDATA-and-overlay-DTB-handling-fo.patch
+RUN patch -p1 --directory=${TEGRA234_35_5_0_DIR} < meta-tegra-kirkstone/recipes-bsp/tegra-binaries/files/0016-Update-tegraflash_impl_t234.py.patch
+RUN patch -p1 --directory=${TEGRA186_35_5_0_DIR} < meta-tegra-kirkstone/recipes-bsp/tegra-binaries/files/0013-Fix-location-of-bsp_version-file-in-l4t_bup_gen.func.patch
+RUN patch -p1 --directory=${TEGRA186_35_5_0_DIR} < meta-tegra-kirkstone/recipes-bsp/tegra-binaries/files/0014-odmsign.func-fix-ODMDATA-and-overlay-DTB-handling-fo.patch

--- a/docker/README.md
+++ b/docker/README.md
@@ -45,6 +45,9 @@ docker run -d \
 --mount type=bind,source=$HOME/$SIGNING_KEYS/NewRoot.pub.pem,target=/digsigserver/$MACHINE/ueficapsulesign/trusted_public_cert.pem,readonly \
 --mount type=bind,source=$HOME/$SIGNING_KEYS/NewSub.pub.pem,target=/digsigserver/$MACHINE/ueficapsulesign/other_public_cert.pem,readonly \
 --mount type=bind,source=$HOME/$SIGNING_KEYS/NewCert.pem,target=/digsigserver/$MACHINE/ueficapsulesign/signer_private_cert.pem,readonly \
+--mount type=bind,source=$HOME/$SIGNING_KEYS/oemk1.key,target=/digsigserver/$MACHINE/ekbsign/oemk1.key,readonly \
+--mount type=bind,source=$HOME/$SIGNING_KEYS/fixed-vector,target=/digsigserver/$MACHINE/ekbsign/fixed-vector,readonly \
+--mount type=bind,source=$HOME/$SIGNING_KEYS/uefi-variable-authentication.key,target=/digsigserver/$MACHINE/ekbsign/uefi-variable-authentication.key,readonly \
 -p 9999:9999 \
 digsigserver:latest
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,8 +6,10 @@ The [Dockerfile](Dockerfile) uses docker's multi-stage builds to support one or 
 
 From the top-level of the `digsigserver` repo build the L4T release container images for the releases you want to support.  Example:
 
-    $ docker build . -f docker/Dockerfile.l4t-32.7.4 -t l4t-release:32.7.4
-    $ docker build . -f docker/Dockerfile.l4t-35.4.1 -t l4t-release:35.4.1
+```
+docker build . -f docker/Dockerfile.l4t-32.7.4 -t l4t-release:32.7.4
+docker build . -f docker/Dockerfile.l4t-35.4.1 -t l4t-release:35.4.1
+```
 
 Include the approriate `FROM` and `COPY` statements in your `Dockerfile`.  Example:
 
@@ -23,7 +25,9 @@ COPY --from=l4t-35.4.1 /opt/nvidia /opt/nvidia
 
 Then build the signing server container image:
 
-    $ docker build . -f docker/Dockerfile -t digsigserver:latest
+```
+docker build . -f docker/Dockerfile -t digsigserver:latest
+```
 
 # Running
 


### PR DESCRIPTION
The main purpose of this PR was to generate and sign the EKB with your own key that became a requirement with the L4T 35.5.0 release.  But, there are a handful of other fixes included:

- cleanup a 'leak' with files created when signing uefi artifacts or uefi capsules
- pin to the correct commit hash in kirkstone for the L4T 35.4.1 version of the dockerfile
- stage nvflashxmlparse for use in signing requests
- minor fix to the docker README markdown