### PR TITLE
opteesign.py: fix exception when .ta-version not present

### DIFF
--- a/digsigserver/signers/opteesign.py
+++ b/digsigserver/signers/opteesign.py
@@ -96,7 +96,10 @@ class OPTEESigner (Signer):
                         self.keys.cleanup()
                         return False
                     os.remove(os.path.join(dirpath, file))
-                    os.remove(os.path.join(dirpath, uuid + ".ta-version"))
+                    try:
+                        os.remove(os.path.join(dirpath, uuid + ".ta-version"))
+                    except FileNotFoundError:
+                        pass
                     if not os.path.exists(os.path.join(dirpath, uuid + ".ta")):
                         logger.warning("TA signing succesful, but {}.ta file is missing".format(uuid))
         self.keys.cleanup()


### PR DESCRIPTION
- The cleanup of the .ta-version file will throw a FileNotFoundError if the file is not present.  Catch the exception and continue.