### PR TITLE
L4t 35.6.0 support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,7 @@ FROM l4t-release:32.5.2 AS l4t-32.5.2
 FROM l4t-release:32.7.4 AS l4t-32.7.4
 FROM l4t-release:35.4.1 AS l4t-35.4.1
 FROM l4t-release:35.5.0 AS l4t-35.5.0
+FROM l4t-release:35.6.0 AS l4t-35.6.0
 
 FROM ubuntu:18.04 as mkimage
 
@@ -53,6 +54,7 @@ COPY --from=l4t-32.5.2 /opt/nvidia /opt/nvidia
 COPY --from=l4t-32.7.4 /opt/nvidia /opt/nvidia
 COPY --from=l4t-35.4.1 /opt/nvidia /opt/nvidia
 COPY --from=l4t-35.5.0 /opt/nvidia /opt/nvidia
+COPY --from=l4t-35.6.0 /opt/nvidia /opt/nvidia
 # Rockchip
 ARG ROCKCHIP_TOOLS_REPO_URL=https://github.com/rockchip-linux/rkbin/raw/829d7a6a2272938aac67dfe9f807277fa617809b/
 ENV DIGSIGSERVER_RK_TOOLS_PATH=/opt

--- a/docker/Dockerfile.l4t-35.6.0
+++ b/docker/Dockerfile.l4t-35.6.0
@@ -1,0 +1,47 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y \
+  git \
+  python3-cryptography \
+  wget \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --branch scarthgap-l4t-r35.x https://github.com/OE4T/meta-tegra.git meta-tegra-scarthgap-l4t-r35.x 
+
+RUN mkdir -p /opt/nvidia/L4T-35.6.0-tegra234 && \
+    mkdir -p /opt/nvidia/L4T-35.6.0-tegra186
+
+RUN wget -q -O /opt/nvidia/l4t-release.tbz2 https://developer.nvidia.com/downloads/embedded/l4t/r35_release_v6.0/release/jetson_linux_r35.6.0_aarch64.tbz2
+
+RUN tar -xjf /opt/nvidia/l4t-release.tbz2 -C /opt/nvidia/L4T-35.6.0-tegra234 && \
+    tar -xjf /opt/nvidia/l4t-release.tbz2 -C /opt/nvidia/L4T-35.6.0-tegra186
+
+RUN rm /opt/nvidia/l4t-release.tbz2
+
+RUN wget -q -O /opt/nvidia/public_sources.tbz2 https://developer.nvidia.com/downloads/embedded/l4t/r35_release_v6.0/sources/public_sources.tbz2
+
+RUN tar -xjf /opt/nvidia/public_sources.tbz2 -C /opt/nvidia/L4T-35.6.0-tegra234 Linux_for_Tegra/source/public/nvidia-jetson-optee-source.tbz2 && \
+    tar -xjf /opt/nvidia/L4T-35.6.0-tegra234/Linux_for_Tegra/source/public/nvidia-jetson-optee-source.tbz2 -C /opt/nvidia/L4T-35.6.0-tegra234/Linux_for_Tegra/source/public
+
+RUN tar -xjf /opt/nvidia/public_sources.tbz2 -C /opt/nvidia/L4T-35.6.0-tegra186 Linux_for_Tegra/source/public/nvidia-jetson-optee-source.tbz2 && \
+    tar -xjf /opt/nvidia/L4T-35.6.0-tegra186/Linux_for_Tegra/source/public/nvidia-jetson-optee-source.tbz2 -C /opt/nvidia/L4T-35.6.0-tegra186/Linux_for_Tegra/source/public
+
+RUN rm /opt/nvidia/public_sources.tbz2 && \
+    rm /opt/nvidia/L4T-35.6.0-tegra234/Linux_for_Tegra/source/public/nvidia-jetson-optee-source.tbz2 && \
+    rm /opt/nvidia/L4T-35.6.0-tegra186/Linux_for_Tegra/source/public/nvidia-jetson-optee-source.tbz2
+
+ARG TEGRA234_35_6_0_DIR=/opt/nvidia/L4T-35.6.0-tegra234/Linux_for_Tegra
+ARG TEGRA186_35_6_0_DIR=/opt/nvidia/L4T-35.6.0-tegra186/Linux_for_Tegra
+
+RUN cd meta-tegra-scarthgap-l4t-r35.x/recipes-bsp/tegra-binaries/tegra-helper-scripts && \
+    install -m 0755 tegra-flash-helper.sh ${TEGRA234_35_6_0_DIR}/bootloader/tegra234-flash-helper && \
+    install -m 0755 tegra-flash-helper.sh ${TEGRA186_35_6_0_DIR}/bootloader/tegra194-flash-helper && \
+    install -m 0755 tegra-signimage-helper.sh ${TEGRA234_35_6_0_DIR}/tegra-signimage-helper && \
+    install -m 0755 tegra-signimage-helper.sh ${TEGRA186_35_6_0_DIR}/tegra-signimage-helper && \
+    install -m 0755 nvflashxmlparse.py ${TEGRA234_35_6_0_DIR}/bootloader/nvflashxmlparse && \
+    install -m 0755 nvflashxmlparse.py ${TEGRA186_35_6_0_DIR}/bootloader/nvflashxmlparse
+
+RUN patch -p1 --directory=${TEGRA234_35_6_0_DIR} < meta-tegra-scarthgap-l4t-r35.x/recipes-bsp/tegra-binaries/files/0013-Fix-location-of-bsp_version-file-in-l4t_bup_gen.func.patch
+RUN patch -p1 --directory=${TEGRA234_35_6_0_DIR} < meta-tegra-scarthgap-l4t-r35.x/recipes-bsp/tegra-binaries/files/0014-odmsign.func-fix-ODMDATA-and-overlay-DTB-handling-fo.patch
+RUN patch -p1 --directory=${TEGRA186_35_6_0_DIR} < meta-tegra-scarthgap-l4t-r35.x/recipes-bsp/tegra-binaries/files/0013-Fix-location-of-bsp_version-file-in-l4t_bup_gen.func.patch
+RUN patch -p1 --directory=${TEGRA186_35_6_0_DIR} < meta-tegra-scarthgap-l4t-r35.x/recipes-bsp/tegra-binaries/files/0014-odmsign.func-fix-ODMDATA-and-overlay-DTB-handling-fo.patch


### PR DESCRIPTION
Added Docker Container support for l4t-r35.6.0. Also taken care of unresolved 0016-Update-tegraflash_impl_t234.py.patch and copied tegra-flash-helper with 194/234 suffix to be compatible with digsigserver until digsigserver is updated to handle the new file name based on the l4t-version.