### PR TITLE
Increased maximum payload size to accept bbigger packages.

### DIFF
--- a/digsigserver/server.py
+++ b/digsigserver/server.py
@@ -25,7 +25,7 @@ from . import utils
 # default response timeout
 CodesignSanicDefaults = {
     'RESPONSE_TIMEOUT': 600,
-    'REQUEST_MAX_SIZE': 600000000,
+    'REQUEST_MAX_SIZE': 60000000000,
     'L4T_TOOLS_BASE': '/opt/nvidia',
     'IMX_CST_BASE': '/opt/NXP',
     'KEYFILE_URI': 'file:///please/configure/this/path',


### PR DESCRIPTION
This commit I've made to avoid that issue that happens when I increase the rootfs size, resulting to failing do_image_tegraflash task due to exceeding the maximum packet size of (tegrasign-in.tar.gz) that digsigservver can accepts.  