### PR TITLE
choose correct commit to match 36.4.0 not 36.4.3

### DIFF
--- a/docker/Dockerfile.l4t-36.4.0
+++ b/docker/Dockerfile.l4t-36.4.0
@@ -6,7 +6,8 @@ RUN apt-get update && apt-get install -y \
   wget \
   && rm -rf /var/lib/apt/lists/*
 
-RUN git clone --branch scarthgap https://github.com/OE4T/meta-tegra.git meta-tegra-scarthgap
+RUN git clone --branch scarthgap https://github.com/OE4T/meta-tegra.git meta-tegra-scarthgap && cd meta-tegra-scarthgap && git checkout e1c238e20c83821b47547cf5956914f43007471e
+
 
 RUN mkdir -p /opt/nvidia/L4T-36.4.0-tegra234
 


### PR DESCRIPTION
There was a problem using Docker-l4t-36.4.0 with scarthgap branch with Jetpack-6.1. Which have resuted to choose the wrong version of tegra-flash-helper and there was no option called "--cpubl_rcm". This is a fix which chooses the last commit using l4t-36.4.0 and lead to choose the corresponding tegra234-flash-helper, tegra-signimage-helper and nvflashxmlparse. 

Future work : 
Write Dockerfile.l4t-36.4.3