### PR TITLE
added support for scarthgap branch l4t-36.4.4

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,7 @@ FROM l4t-release:35.5.0 AS l4t-35.5.0
 FROM l4t-release:35.6.0 AS l4t-35.6.0
 FROM l4t-release:36.4.0 AS l4t-36.4.0
 FROM l4t-release:36.4.3 AS l4t-36.4.3
+FROM l4t-release:36.4.4 AS l4t-36.4.4
 FROM ubuntu:18.04 as mkimage
 
 # Dependencies for building u-boot tools
@@ -58,6 +59,7 @@ COPY --from=l4t-35.5.0 /opt/nvidia /opt/nvidia
 COPY --from=l4t-35.6.0 /opt/nvidia /opt/nvidia
 COPY --from=l4t-36.4.0 /opt/nvidia /opt/nvidia
 COPY --from=l4t-36.4.3 /opt/nvidia /opt/nvidia
+COPY --from=l4t-36.4.4 /opt/nvidia /opt/nvidia
 # Rockchip
 ARG ROCKCHIP_TOOLS_REPO_URL=https://github.com/rockchip-linux/rkbin/raw/829d7a6a2272938aac67dfe9f807277fa617809b/
 ENV DIGSIGSERVER_RK_TOOLS_PATH=/opt

--- a/docker/Dockerfile.l4t-36.4.4
+++ b/docker/Dockerfile.l4t-36.4.4
@@ -1,0 +1,35 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y \
+  git \
+  python3-cryptography \
+  wget \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --branch scarthgap https://github.com/OE4T/meta-tegra.git meta-tegra-scarthgap
+
+RUN mkdir -p /opt/nvidia/L4T-36.4.4-tegra234
+
+RUN wget -q -O /opt/nvidia/l4t-release.tbz2 https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v4.3/release/Jetson_Linux_R36.4.4_aarch64.tbz2
+
+RUN tar -xjf /opt/nvidia/l4t-release.tbz2 -C /opt/nvidia/L4T-36.4.4-tegra234
+
+RUN rm /opt/nvidia/l4t-release.tbz2
+
+RUN wget -q -O /opt/nvidia/public_sources.tbz2 https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v4.3/sources/public_sources.tbz2
+
+RUN tar -xjf /opt/nvidia/public_sources.tbz2 -C /opt/nvidia/L4T-36.4.4-tegra234 Linux_for_Tegra/source/nvidia-jetson-optee-source.tbz2 && \
+    mkdir /opt/nvidia/L4T-36.4.4-tegra234/Linux_for_Tegra/source/public && \
+    tar -xjf /opt/nvidia/L4T-36.4.4-tegra234/Linux_for_Tegra/source/nvidia-jetson-optee-source.tbz2 -C /opt/nvidia/L4T-36.4.4-tegra234/Linux_for_Tegra/source/public
+
+RUN rm /opt/nvidia/public_sources.tbz2 && \
+    rm /opt/nvidia/L4T-36.4.4-tegra234/Linux_for_Tegra/source/nvidia-jetson-optee-source.tbz2
+
+ARG TEGRA234_36_4_4_DIR=/opt/nvidia/L4T-36.4.4-tegra234/Linux_for_Tegra
+
+RUN cd meta-tegra-scarthgap/recipes-bsp/tegra-binaries/tegra-helper-scripts && \
+    install -m 0755 tegra-flash-helper.sh ${TEGRA234_36_4_4_DIR}/bootloader/tegra234-flash-helper && \
+    install -m 0755 tegra-signimage-helper.sh ${TEGRA234_36_4_4_DIR}/tegra-signimage-helper && \
+    install -m 0755 nvflashxmlparse.py ${TEGRA234_36_4_4_DIR}/bootloader/nvflashxmlparse
+
+RUN patch -p1 --directory=${TEGRA234_36_4_4_DIR} < meta-tegra-scarthgap/recipes-bsp/tegra-binaries/files/0013-Fix-location-of-bsp_version-file-in-l4t_bup_gen.func.patch


### PR DESCRIPTION
Addded New container to support Builds for current scarthgap Branch. Which is based on L4T-36.4.4