### PR TITLE
Add PKCS#11 support for FIT image and SWUpdate signing

### DIFF
--- a/digsigserver/logredaction.py
+++ b/digsigserver/logredaction.py
@@ -1,0 +1,46 @@
+import logging
+from typing import Any
+
+
+class SecretRedactionFilter(logging.Filter):
+    def __init__(self) -> None:
+        super().__init__()
+        self._secrets: list[str] = []
+
+    def set_secrets(self, secrets: list[str]) -> None:
+        self._secrets = [secret for secret in secrets if secret]
+
+    def _redact(self, value: Any) -> Any:
+        if isinstance(value, str):
+            for secret in self._secrets:
+                value = value.replace(secret, '<redacted>')
+            return value
+        if isinstance(value, tuple):
+            return tuple(self._redact(item) for item in value)
+        if isinstance(value, list):
+            return [self._redact(item) for item in value]
+        if isinstance(value, dict):
+            return {key: self._redact(item) for key, item in value.items()}
+        return value
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.msg = self._redact(record.msg)
+        record.args = self._redact(record.args)
+        if hasattr(record, 'exc_text'):
+            record.exc_text = None
+        return True
+
+
+def install_log_redaction_filter(secrets: list[str]) -> SecretRedactionFilter:
+    for logger_name in ('', 'sanic.root', 'sanic.error', 'sanic.access'):
+        target_logger = logging.getLogger(logger_name)
+        for existing_filter in target_logger.filters:
+            if isinstance(existing_filter, SecretRedactionFilter):
+                existing_filter.set_secrets(secrets)
+                return existing_filter
+    redaction_filter = SecretRedactionFilter()
+    redaction_filter.set_secrets(secrets)
+    for logger_name in ('', 'sanic.root', 'sanic.error', 'sanic.access'):
+        target_logger = logging.getLogger(logger_name)
+        target_logger.addFilter(redaction_filter)
+    return redaction_filter

--- a/digsigserver/server.py
+++ b/digsigserver/server.py
@@ -38,7 +38,28 @@ Actual initialization happens here
 """
 
 
+def load_dotenv(path: str = '.env') -> None:
+    if not os.path.exists(path):
+        return
+    with open(path, mode='r', encoding='utf-8') as f:
+        for raw_line in f:
+            line = raw_line.strip()
+            if not line or line.startswith('#'):
+                continue
+            if line.startswith('export '):
+                line = line[7:].lstrip()
+            key, sep, value = line.partition('=')
+            if not sep:
+                continue
+            key = key.strip()
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                value = value[1:-1]
+            os.environ.setdefault(key, value)
+
+
 def create_app() -> Sanic:
+    load_dotenv(os.environ.get('DIGSIGSERVER_DOTENV', '.env'))
     app = Sanic(name='digsigserver', env_prefix='DIGSIGSERVER_')
     app.config.update_config(CodesignSanicDefaults)
     app.config.load_environment_vars(prefix='DIGSIGSERVER_')
@@ -98,6 +119,10 @@ async def return_tarball(req: request, workdir: str, return_filename: str = "sig
 
 
 def attach_endpoints(app: Sanic):
+    @app.get("/health")
+    async def health_handler(req: request):
+        return text("OK")
+  
     @app.post("/sign/tegra")
     async def sign_handler_tegra(req: request):
         f = validate_upload(req, "artifact")
@@ -371,12 +396,8 @@ def attach_endpoints(app: Sanic):
         if not method:
             method = "RSA"
         key_uri = req.form.get("key-uri")
-        cert_uri = req.form.get("cert-uri")
-        if backend == "pkcs11":
-          if method == "RSA" and not key_uri:
+        if backend == "pkcs11" and not key_uri:
             return text("Key URI missing for PKCS#11 backend", status=400)
-          elif method == "CMS" and (not key_uri or not cert_uri):
-            return text("Key URI or cert URI missing for CMS signing with PKCS#11 backend", status=400)  
         f = validate_upload(req, "sw-description")
         if not f:
             return text("Invalid sw-description", status=400)
@@ -392,7 +413,7 @@ def attach_endpoints(app: Sanic):
                 infile.write(f.body.decode('UTF-8'))
             if await asyncio.get_running_loop().run_in_executor(None, s.sign,
                                                                 method, "sw-description",
-                                                                outfile.name, key_uri, cert_uri):
+                                                                outfile.name, key_uri):
                 await return_file(req, outfile.name, "sw-description.sig")
                 response = None
             else:

--- a/digsigserver/server.py
+++ b/digsigserver/server.py
@@ -364,17 +364,25 @@ def attach_endpoints(app: Sanic):
     @app.post("/sign/swupdate")
     async def sign_handler_swupdate(req: request):
         distro = req.form.get("distro")
-        if not distro:
+        backend = req.form.get("backend")
+        if not distro and (not backend or backend != "pkcs11"):
             return text("Distro name missing", status=400)
         method = req.form.get("method")
         if not method:
             method = "RSA"
+        key_uri = req.form.get("key-uri")
+        cert_uri = req.form.get("cert-uri")
+        if backend == "pkcs11":
+          if method == "RSA" and not key_uri:
+            return text("Key URI missing for PKCS#11 backend", status=400)
+          elif method == "CMS" and (not key_uri or not cert_uri):
+            return text("Key URI or cert URI missing for CMS signing with PKCS#11 backend", status=400)  
         f = validate_upload(req, "sw-description")
         if not f:
             return text("Invalid sw-description", status=400)
         with tempfile.TemporaryDirectory() as workdir:
             try:
-                s = SwupdateSigner(app, workdir, distro)
+                s = SwupdateSigner(app, workdir, distro, backend)
             except ValueError:
                 logger.info("could not init signer")
                 return text("Invalid parameters", status=400)
@@ -384,7 +392,7 @@ def attach_endpoints(app: Sanic):
                 infile.write(f.body.decode('UTF-8'))
             if await asyncio.get_running_loop().run_in_executor(None, s.sign,
                                                                 method, "sw-description",
-                                                                outfile.name):
+                                                                outfile.name, key_uri, cert_uri):
                 await return_file(req, outfile.name, "sw-description.sig")
                 response = None
             else:

--- a/digsigserver/server.py
+++ b/digsigserver/server.py
@@ -5,6 +5,7 @@ import re
 import os
 
 from sanic import Sanic, request
+from sanic.exceptions import SanicException
 from sanic.log import logger
 from sanic.response import text
 
@@ -53,6 +54,8 @@ def create_app() -> Sanic:
 def attach_exception_handlers(app: Sanic):
     @app.exception(Exception)
     async def handle_unexpected_error(req: request, exc: Exception):
+        if isinstance(exc, SanicException):
+            raise exc
         logger.exception('Unhandled application failure')
         return text('Signing error', status=500)
 

--- a/digsigserver/server.py
+++ b/digsigserver/server.py
@@ -20,6 +20,7 @@ from digsigserver.signers.uefisign import UefiSigner
 from digsigserver.signers.ueficapsulesign import UefiCapsuleSigner
 from digsigserver.signers.ekbsign import EKBSigner
 from digsigserver.signers.fitimagesign import FitImageSigner
+from digsigserver.logredaction import install_log_redaction_filter
 from . import utils
 
 # Signing can take a loooong time, so set a more reasonable
@@ -63,9 +64,18 @@ def create_app() -> Sanic:
     app = Sanic(name='digsigserver', env_prefix='DIGSIGSERVER_')
     app.config.update_config(CodesignSanicDefaults)
     app.config.load_environment_vars(prefix='DIGSIGSERVER_')
+    install_log_redaction_filter([app.config.get('YUBIHSM_PASSWORD')])
     logger.setLevel(app.config.get("LOG_LEVEL"))
+    attach_exception_handlers(app)
     attach_endpoints(app)
     return app
+
+
+def attach_exception_handlers(app: Sanic):
+    @app.exception(Exception)
+    async def handle_unexpected_error(req: request, exc: Exception):
+        logger.exception('Unhandled application failure')
+        return text('Signing error', status=500)
 
 
 def config_get(item: str, default_value=None) -> str:
@@ -122,7 +132,7 @@ def attach_endpoints(app: Sanic):
     @app.get("/health")
     async def health_handler(req: request):
         return text("OK")
-  
+
     @app.post("/sign/tegra")
     async def sign_handler_tegra(req: request):
         f = validate_upload(req, "artifact")
@@ -389,9 +399,9 @@ def attach_endpoints(app: Sanic):
     @app.post("/sign/swupdate")
     async def sign_handler_swupdate(req: request):
         distro = req.form.get("distro")
-        backend = req.form.get("backend")
-        if not distro and (not backend or backend != "pkcs11"):
+        if not distro:
             return text("Distro name missing", status=400)
+        backend = req.form.get("backend")
         method = req.form.get("method")
         if not method:
             method = "RSA"

--- a/digsigserver/server.py
+++ b/digsigserver/server.py
@@ -39,28 +39,7 @@ Actual initialization happens here
 """
 
 
-def load_dotenv(path: str = '.env') -> None:
-    if not os.path.exists(path):
-        return
-    with open(path, mode='r', encoding='utf-8') as f:
-        for raw_line in f:
-            line = raw_line.strip()
-            if not line or line.startswith('#'):
-                continue
-            if line.startswith('export '):
-                line = line[7:].lstrip()
-            key, sep, value = line.partition('=')
-            if not sep:
-                continue
-            key = key.strip()
-            value = value.strip()
-            if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
-                value = value[1:-1]
-            os.environ.setdefault(key, value)
-
-
 def create_app() -> Sanic:
-    load_dotenv(os.environ.get('DIGSIGSERVER_DOTENV', '.env'))
     app = Sanic(name='digsigserver', env_prefix='DIGSIGSERVER_')
     app.config.update_config(CodesignSanicDefaults)
     app.config.load_environment_vars(prefix='DIGSIGSERVER_')
@@ -129,10 +108,6 @@ async def return_tarball(req: request, workdir: str, return_filename: str = "sig
 
 
 def attach_endpoints(app: Sanic):
-    @app.get("/health")
-    async def health_handler(req: request):
-        return text("OK")
-
     @app.post("/sign/tegra")
     async def sign_handler_tegra(req: request):
         f = validate_upload(req, "artifact")

--- a/digsigserver/server.py
+++ b/digsigserver/server.py
@@ -200,7 +200,7 @@ def attach_endpoints(app: Sanic):
             return text("Invalid artifact", status=400)
         with tempfile.TemporaryDirectory() as workdir:
             try:
-                s = FitImageSigner(app, workdir)
+                s = FitImageSigner(app, workdir, req.form.get("backend"))
             except ValueError:
                 return text("Invalid parameters", status=400)
 

--- a/digsigserver/server.py
+++ b/digsigserver/server.py
@@ -233,9 +233,15 @@ def attach_endpoints(app: Sanic):
         f = validate_upload(req, "artifact")
         if not f:
             return text("Invalid artifact", status=400)
+        backend = req.form.get("backend")
+        keyname = req.form.get("keyname")
+        if backend == "pkcs11" and not keyname:
+            return text("Key URI missing for PKCS#11 backend", status=400)
+        if not keyname:
+            keyname = "dev"
         with tempfile.TemporaryDirectory() as workdir:
             try:
-                s = FitImageSigner(app, workdir, req.form.get("backend"))
+                s = FitImageSigner(app, workdir, backend)
             except ValueError:
                 return text("Invalid parameters", status=400)
 
@@ -249,8 +255,9 @@ def attach_endpoints(app: Sanic):
                                    None,
                                    req.form.get("external_data_offset"),
                                    req.form.get("mark_required"),
-                                   req.form.get("algo"),
-                                   req.form.get("keyname")):
+                                    req.form.get("algo"),
+                                   keyname,
+                                   req.form.get("comment")):
                 await return_file(req, artifact.name, "artifact.signed")
                 response = None
             else:

--- a/digsigserver/signers/fitimagesign.py
+++ b/digsigserver/signers/fitimagesign.py
@@ -11,8 +11,7 @@ class FitImageSigner (Signer):
     keytag = 'fitimagesign'
 
     def __init__(self, app: Sanic, workdir: str, backend: str):
-        super().__init__(app, workdir)
-        self.backend = backend
+        super().__init__(app, workdir, 'imx', backend, load_keys=backend != 'pkcs11')
 
     def _prepare_path(self) -> dict:
         env = dict(copy.deepcopy(os.environ))
@@ -44,5 +43,4 @@ class FitImageSigner (Signer):
 
         cmd += [ fitimage ]
         result = self.run_command(cmd, env=env)
-        self.keys.cleanup()
         return result

--- a/digsigserver/signers/fitimagesign.py
+++ b/digsigserver/signers/fitimagesign.py
@@ -25,23 +25,27 @@ class FitImageSigner (Signer):
              external_data_offset: Optional[str],
              mark_required: Optional[bool],
              algo: Optional[str],
-             keyname: str = "dev.key") -> bool:
+             keyname: str = "dev",
+             comment: Optional[str] = None) -> bool:
         env = self._prepare_path()
         if self.backend == "pkcs11":
-          keyname = keyname.replace('pin-value=password', 'pin-value=' + self.app.config.get('YUBIHSM_PASSWORD'))
-          cmd = [ 'mkimage', '-E', '-F', '-N', 'pkcs11', '-k', keyname, '-c', 'fit-image-td', '-v', '-r' ]
-        else: 
-          private_key = self.keys.get("{}.key".format(keyname))
-          cmd = [ 'mkimage', '-F', '-k', os.path.dirname(private_key) ]
-          if external_data_offset:
-              cmd += [ '-p', external_data_offset ]
-          if mark_required:
-              cmd += [ '-r' ]
-          if dtb:
-              cmd += [ '-K', dtb ]
-          if algo:
-              cmd +=[ '-o', algo ]
+            keyname = keyname.replace('pin-value=password', 'pin-value=' + self.app.config.get('YUBIHSM_PASSWORD'))
+            cmd = ['mkimage', '-E', '-F', '-N', 'pkcs11', '-k', keyname, '-v']
+        else:
+            private_key = self.keys.get("{}.key".format(keyname))
+            cmd = ['mkimage', '-F', '-k', os.path.dirname(private_key)]
 
-        cmd += [ fitimage ]
+        if comment:
+            cmd += ['-c', comment]
+        if external_data_offset:
+            cmd += ['-p', external_data_offset]
+        if mark_required:
+            cmd += ['-r']
+        if dtb:
+            cmd += ['-K', dtb]
+        if algo:
+            cmd += ['-o', algo]
+
+        cmd += [fitimage]
         result = self.run_command(cmd, env=env)
         return result

--- a/digsigserver/signers/fitimagesign.py
+++ b/digsigserver/signers/fitimagesign.py
@@ -28,6 +28,7 @@ class FitImageSigner (Signer):
              keyname: str = "dev.key") -> bool:
         env = self._prepare_path()
         if self.backend == "pkcs11":
+          keyname = keyname.replace('pin-value=password', 'pin-value=' + self.app.config.get('YUBIHSM_PASSWORD'))
           cmd = [ 'mkimage', '-E', '-F', '-N', 'pkcs11', '-k', keyname, '-c', 'fit-image-td', '-v', '-r' ]
         else: 
           private_key = self.keys.get("{}.key".format(keyname))

--- a/digsigserver/signers/fitimagesign.py
+++ b/digsigserver/signers/fitimagesign.py
@@ -10,8 +10,9 @@ class FitImageSigner (Signer):
 
     keytag = 'fitimagesign'
 
-    def __init__(self, app: Sanic, workdir: str):
-        super().__init__(app, workdir, "imx")
+    def __init__(self, app: Sanic, workdir: str, backend: str):
+        super().__init__(app, workdir)
+        self.backend = backend
 
     def _prepare_path(self) -> dict:
         env = dict(copy.deepcopy(os.environ))
@@ -26,17 +27,20 @@ class FitImageSigner (Signer):
              mark_required: Optional[bool],
              algo: Optional[str],
              keyname: str = "dev.key") -> bool:
-        private_key = self.keys.get("{}.key".format(keyname))
         env = self._prepare_path()
-        cmd = [ 'mkimage', '-F', '-k', os.path.dirname(private_key) ]
-        if external_data_offset:
-            cmd += [ '-p', external_data_offset ]
-        if mark_required:
-            cmd += [ '-r' ]
-        if dtb:
-            cmd += [ '-K', dtb ]
-        if algo:
-            cmd +=[ '-o', algo ]
+        if self.backend == "pkcs11":
+          cmd = [ 'mkimage', '-E', '-F', '-N', 'pkcs11', '-k', keyname, '-c', 'fit-image-td', '-v', '-r' ]
+        else: 
+          private_key = self.keys.get("{}.key".format(keyname))
+          cmd = [ 'mkimage', '-F', '-k', os.path.dirname(private_key) ]
+          if external_data_offset:
+              cmd += [ '-p', external_data_offset ]
+          if mark_required:
+              cmd += [ '-r' ]
+          if dtb:
+              cmd += [ '-K', dtb ]
+          if algo:
+              cmd +=[ '-o', algo ]
 
         cmd += [ fitimage ]
         result = self.run_command(cmd, env=env)

--- a/digsigserver/signers/imxsign.py
+++ b/digsigserver/signers/imxsign.py
@@ -22,8 +22,7 @@ class IMXSigner (Signer):
             raise ValueError("no tools available for cstversion={}".format(cstversion))
         self.soctype = soctype
         self.machine = machine
-        self.backend = backend
-        super().__init__(app, workdir, machine)
+        super().__init__(app, workdir, machine, backend)
 
     def _prepare_path(self) -> dict:
         env = dict(copy.deepcopy(os.environ))

--- a/digsigserver/signers/imxsign.py
+++ b/digsigserver/signers/imxsign.py
@@ -46,7 +46,7 @@ class IMXSigner (Signer):
                 with open(cst_path, "r") as f:
                     content = f.read()
                 with open(cst_path, "w") as f:
-                    new_content = content.replace("pin-value=password", "pin-value=" + os.environ.get('YUBIHSM_PASSWORD'))
+                    new_content = content.replace("pin-value=password", "pin-value=" + self.app.config.get('YUBIHSM_PASSWORD'))
                     f.write(new_content)
             if self.run_command(command, env=env):
                 self.keys.cleanup()

--- a/digsigserver/signers/signer.py
+++ b/digsigserver/signers/signer.py
@@ -14,10 +14,16 @@ class Signer:
                  backend: Optional[str] = None, load_keys: bool = True):
         self.app = app
         self.workdir = workdir
+        self.key_selector = key_selector
         self.backend = backend or 'ssl'
         self.keys = None
         if load_keys:
             self.keys = KeyFiles(app, self.keytag, key_selector)
+
+    def ensure_keys_loaded(self) -> KeyFiles:
+        if not self.keys:
+            self.keys = KeyFiles(self.app, self.keytag, self.key_selector)
+        return self.keys
 
     def sign(self, *args) -> bool:
         raise RuntimeError("unimplemented sign method")

--- a/digsigserver/signers/signer.py
+++ b/digsigserver/signers/signer.py
@@ -10,10 +10,14 @@ class Signer:
 
     keytag = 'Unknown'
 
-    def __init__(self, app: Sanic, workdir: str, key_selector: str):
+    def __init__(self, app: Sanic, workdir: str, key_selector: Optional[str] = None,
+                 backend: Optional[str] = None, load_keys: bool = True):
         self.app = app
         self.workdir = workdir
-        self.keys = KeyFiles(app, self.keytag, key_selector)
+        self.backend = backend or 'ssl'
+        self.keys = None
+        if load_keys:
+            self.keys = KeyFiles(app, self.keytag, key_selector)
 
     def sign(self, *args) -> bool:
         raise RuntimeError("unimplemented sign method")
@@ -30,11 +34,11 @@ class Signer:
             logger.debug("stdout: {}".format(proc.stdout))
             logger.debug("stderr: {}".format(proc.stderr))
         except subprocess.CalledProcessError as e:
-            if cleanup:
+            if cleanup and self.keys:
                 self.keys.cleanup()
             logger.warning("signing error: {}".format(e.stderr))
             logger.warning("stdout: {}".format(e.stdout))
             return False
-        if cleanup:
+        if cleanup and self.keys:
             self.keys.cleanup()
         return True

--- a/digsigserver/signers/signer.py
+++ b/digsigserver/signers/signer.py
@@ -38,6 +38,7 @@ class Signer:
                 self.keys.cleanup()
             logger.warning("signing error: {}".format(e.stderr))
             logger.warning("stdout: {}".format(e.stdout))
+            logger.warning("return code: {}".format(e.returncode))
             return False
         if cleanup and self.keys:
             self.keys.cleanup()

--- a/digsigserver/signers/swupdsign.py
+++ b/digsigserver/signers/swupdsign.py
@@ -6,28 +6,38 @@ from sanic import Sanic
 class SwupdateSigner(Signer):
     keytag = 'swupdate'
 
-    def __init__(self, app: Sanic, workdir: str, distro: str):
+    def __init__(self, app: Sanic, workdir: str, distro: str, backend: str):
         signcmd = shutil.which('openssl')
         if not signcmd:
             raise RuntimeError('no openssl command')
         self.signcmd = signcmd
+        self.backend = backend
         super().__init__(app, workdir, distro)
 
-    def sign(self, method: str, sw_description: str, outfile: str) -> bool:
-        if method == "RSA":
-            privkey = self.keys.get('rsa-private.key')
-            if not privkey:
-                raise RuntimeError('RSA private key missing for swupdate signing')
-            cmd = [self.signcmd, 'dgst', '-sha256', '-sign', privkey, '-out', outfile, sw_description]
-        elif method == "CMS":
-            cms_cert = self.keys.get('cms.cert')
-            cms_key = self.keys.get('cms-private.key')
-            if not cms_cert or not cms_key:
-                raise RuntimeError('CMS cert or private key missing for swupdate signing')
-            cmd = [self.signcmd, 'cms', '-sign', '-in', sw_description, '-out', outfile,
-                   '-signer', cms_cert, '-inkey', cms_key, '-outform', 'DER',
-                   '-nosmimecap', '-binary']
-        else:
-            raise RuntimeError('Unrecognized signing method {} - must be RSA or CMS'.format(method))
+    def sign(self, method: str, sw_description: str, outfile: str, key_uri: str = None, cert_uri: str = None) -> bool:
+        match (method, self.backend):
+            case ("RSA", "ssl"):
+                privkey = self.keys.get('rsa-private.key')
+                if not privkey:
+                    raise RuntimeError('RSA private key missing for swupdate signing')
+                cmd = [self.signcmd, 'dgst', '-sha256', '-sign', privkey, '-out', outfile, sw_description]
+            case ("CMS", "ssl"):
+                cms_cert = self.keys.get('cms.cert')
+                cms_key = self.keys.get('cms-private.key')
+                if not cms_cert or not cms_key:
+                    raise RuntimeError('CMS cert or private key missing for swupdate signing')
+                cmd = [self.signcmd, 'cms', '-sign', '-in', sw_description, '-out', outfile,
+                       '-signer', cms_cert, '-inkey', cms_key, '-outform', 'DER',
+                       '-nosmimecap', '-binary']
+            case ("RSA", "pkcs11"):
+                if not key_uri:
+                    raise RuntimeError('Key URI missing for RSA signing with PKCS#11 backend')
+                raise NotImplementedError('RSA signing with PKCS#11 backend not implemented yet')
+            case ("CMS", "pkcs11"):
+                if not key_uri or not cert_uri:
+                    raise RuntimeError('Key URI or cert URI missing for CMS signing with PKCS#11 backend')
+                # TODO
+            case _:
+              raise RuntimeError('Unrecognized signing method {} or backend {} allowed: RSA, CMS with ssl or pkcs11'.format(method, self.backend))
 
         return self.run_command(cmd)

--- a/digsigserver/signers/swupdsign.py
+++ b/digsigserver/signers/swupdsign.py
@@ -11,8 +11,7 @@ class SwupdateSigner(Signer):
         if not signcmd:
             raise RuntimeError('no openssl command')
         self.signcmd = signcmd
-        self.backend = backend
-        super().__init__(app, workdir, distro)
+        super().__init__(app, workdir, distro, backend, load_keys=backend != 'pkcs11')
 
     def sign(self, method: str, sw_description: str, outfile: str, key_uri: str = None, cert_uri: str = None) -> bool:
         match (method, self.backend):
@@ -32,11 +31,15 @@ class SwupdateSigner(Signer):
             case ("RSA", "pkcs11"):
                 if not key_uri:
                     raise RuntimeError('Key URI missing for RSA signing with PKCS#11 backend')
-                raise NotImplementedError('RSA signing with PKCS#11 backend not implemented yet')
+                cmd = [self.signcmd, 'dgst', '-sha256', '-engine', 'pkcs11',
+                       '-keyform', 'ENGINE', '-sign', key_uri, '-out', outfile, sw_description]
             case ("CMS", "pkcs11"):
                 if not key_uri or not cert_uri:
                     raise RuntimeError('Key URI or cert URI missing for CMS signing with PKCS#11 backend')
-                # TODO
+                cmd = [self.signcmd, 'cms', '-sign', '-engine', 'pkcs11',
+                       '-keyform', 'ENGINE', '-in', sw_description, '-out', outfile,
+                       '-signer', cert_uri, '-inkey', key_uri, '-outform', 'DER',
+                       '-nosmimecap', '-binary']
             case _:
               raise RuntimeError('Unrecognized signing method {} or backend {} allowed: RSA, CMS with ssl or pkcs11'.format(method, self.backend))
 

--- a/digsigserver/signers/swupdsign.py
+++ b/digsigserver/signers/swupdsign.py
@@ -11,9 +11,9 @@ class SwupdateSigner(Signer):
         if not signcmd:
             raise RuntimeError('no openssl command')
         self.signcmd = signcmd
-        super().__init__(app, workdir, distro, backend, load_keys=backend != 'pkcs11')
+        super().__init__(app, workdir, distro, backend)
 
-    def sign(self, method: str, sw_description: str, outfile: str, key_uri: str = None, cert_uri: str = None) -> bool:
+    def sign(self, method: str, sw_description: str, outfile: str, key_uri: str = None) -> bool:
         match (method, self.backend):
             case ("RSA", "ssl"):
                 privkey = self.keys.get('rsa-private.key')
@@ -31,13 +31,16 @@ class SwupdateSigner(Signer):
             case ("RSA", "pkcs11"):
                 if not key_uri:
                     raise RuntimeError('Key URI missing for RSA signing with PKCS#11 backend')
+                key_uri = key_uri.replace('pin-value=password', 'pin-value=' + self.app.config.get('YUBIHSM_PASSWORD'))
                 cmd = [self.signcmd, 'dgst', '-sha256', '-engine', 'pkcs11',
                        '-keyform', 'ENGINE', '-sign', key_uri, '-out', outfile, sw_description]
             case ("CMS", "pkcs11"):
-                if not key_uri or not cert_uri:
-                    raise RuntimeError('Key URI or cert URI missing for CMS signing with PKCS#11 backend')
+                if not key_uri:
+                    raise RuntimeError('Key URI missing for CMS signing with PKCS#11 backend')
+                key_uri = key_uri.replace('pin-value=password', 'pin-value=' + self.app.config.get('YUBIHSM_PASSWORD'))
+                cert_uri = self.keys.get("cms.cert")
                 cmd = [self.signcmd, 'cms', '-sign', '-engine', 'pkcs11',
-                       '-keyform', 'ENGINE', '-in', sw_description, '-out', outfile,
+                       '-keyform', 'engine', '-in', sw_description, '-out', outfile,
                        '-signer', cert_uri, '-inkey', key_uri, '-outform', 'DER',
                        '-nosmimecap', '-binary']
             case _:

--- a/digsigserver/signers/swupdsign.py
+++ b/digsigserver/signers/swupdsign.py
@@ -11,18 +11,20 @@ class SwupdateSigner(Signer):
         if not signcmd:
             raise RuntimeError('no openssl command')
         self.signcmd = signcmd
-        super().__init__(app, workdir, distro, backend)
+        super().__init__(app, workdir, distro, backend, load_keys=backend != 'pkcs11')
 
     def sign(self, method: str, sw_description: str, outfile: str, key_uri: str = None) -> bool:
         match (method, self.backend):
             case ("RSA", "ssl"):
-                privkey = self.keys.get('rsa-private.key')
+                keys = self.ensure_keys_loaded()
+                privkey = keys.get('rsa-private.key')
                 if not privkey:
                     raise RuntimeError('RSA private key missing for swupdate signing')
                 cmd = [self.signcmd, 'dgst', '-sha256', '-sign', privkey, '-out', outfile, sw_description]
             case ("CMS", "ssl"):
-                cms_cert = self.keys.get('cms.cert')
-                cms_key = self.keys.get('cms-private.key')
+                keys = self.ensure_keys_loaded()
+                cms_cert = keys.get('cms.cert')
+                cms_key = keys.get('cms-private.key')
                 if not cms_cert or not cms_key:
                     raise RuntimeError('CMS cert or private key missing for swupdate signing')
                 cmd = [self.signcmd, 'cms', '-sign', '-in', sw_description, '-out', outfile,
@@ -38,7 +40,7 @@ class SwupdateSigner(Signer):
                 if not key_uri:
                     raise RuntimeError('Key URI missing for CMS signing with PKCS#11 backend')
                 key_uri = key_uri.replace('pin-value=password', 'pin-value=' + self.app.config.get('YUBIHSM_PASSWORD'))
-                cert_uri = self.keys.get("cms.cert")
+                cert_uri = self.ensure_keys_loaded().get('cms.cert')
                 cmd = [self.signcmd, 'cms', '-sign', '-engine', 'pkcs11',
                        '-keyform', 'engine', '-in', sw_description, '-out', outfile,
                        '-signer', cert_uri, '-inkey', key_uri, '-outform', 'DER',

--- a/doc/fitimage.md
+++ b/doc/fitimage.md
@@ -23,7 +23,7 @@ Optional parameters:
 * `external_data_offset=<offset>` - external data offset to be used during FIT signing
 * `mark_required=<any value>` - if this parameter exists the key will be marked as required
 * `algo=<signing algorithm>` - customize the signing algorithm
-* `keyname=<name of the key to use>` - specify a keyname other than `dev`
+* `keyname=<name of the key to use or pcks11 uri>` - specify a keyname other than `dev`
 * `backend=<backend-type>` - backend can be pkcs11 or ssl, defaults to ssl if ommitted
 
 Response: signed binary

--- a/doc/fitimage.md
+++ b/doc/fitimage.md
@@ -23,8 +23,9 @@ Optional parameters:
 * `external_data_offset=<offset>` - external data offset to be used during FIT signing
 * `mark_required=<any value>` - if this parameter exists the key will be marked as required
 * `algo=<signing algorithm>` - customize the signing algorithm
-* `keyname=<name of the key to use or pcks11 uri>` - specify a keyname other than `dev`
-* `backend=<backend-type>` - backend can be pkcs11 or ssl, defaults to ssl if ommitted
+* `comment=<text>` - add a comment to the FIT signature node
+* `keyname=<name of the key to use or pkcs11 uri>` - specify a keyname other than `dev`; required for `backend=pkcs11`
+* `backend=<backend-type>` - backend can be `pkcs11` or `ssl`, defaults to `ssl` if omitted
 
 Response: signed binary
 
@@ -38,4 +39,3 @@ Example usage:
 ## Future improvements
 * Enable including a device tree blob in which the public key is injected.
 * Change the `imx` "machine" to something more logical, this is not machine dependent
-

--- a/doc/fitimage.md
+++ b/doc/fitimage.md
@@ -24,6 +24,7 @@ Optional parameters:
 * `mark_required=<any value>` - if this parameter exists the key will be marked as required
 * `algo=<signing algorithm>` - customize the signing algorithm
 * `keyname=<name of the key to use>` - specify a keyname other than `dev`
+* `backend=<backend-type>` - backend can be pkcs11 or ssl, defaults to ssl if ommitted
 
 Response: signed binary
 

--- a/doc/imxsign-yubihsm.md
+++ b/doc/imxsign-yubihsm.md
@@ -204,7 +204,7 @@ The signing server can be run using the following command :
 docker run \
   --restart unless-stopped \
   --privileged -v /dev/bus/usb:/dev/bus/usb \
-  --env "YUBIHSM_PASSWORD=0001password" \
+  --env "DIGSIGSERVER_YUBIHSM_PASSWORD=0001password" \
   -p 9999:9999 \
   --mount type=bind,source=$HOME/imx-cst-keys.tar.gz,target=/digsigserver/{machine}/imxsign/imx-cst-keys.tar.gz,readonly \
   digsigserver-nxp-hsm:latest
@@ -212,9 +212,9 @@ docker run \
 Note the {machine} placeholder identifies your hardware, for example it would normally be 
 set to the MACHINE variable in a yocto build.
 
-The environment variable YUBIHSM_PASSWORD is used by the signing server to login to
-the YubiHSM. As mentioned before, the 0001 prefix is required by pkcs11, and this is
-immediately followed by the actual password.
+The environment variable DIGSIGSERVER_YUBIHSM_PASSWORD is used by the signing
+server to log in to the YubiHSM. As mentioned before, the `0001` prefix is
+required by PKCS#11, and this is immediately followed by the actual password.
 
 Also, when there is no command at the end of the 'docker run' command, the default
 command given in the dockerfile is run, in this case
@@ -261,5 +261,4 @@ curl --connect-timeout 30 --max-time 1800 --retry 4 --silent --fail \
      --output ${HOME}/imx-cst-keys/flash_evk-csf-fit.bin \
      http://172.17.0.1:9999/sign/imx
 ```
-
 

--- a/doc/swupdsign.md
+++ b/doc/swupdsign.md
@@ -27,8 +27,14 @@ Request type: `POST`
 Endpoint: `/sign/swupdate`
 
 Expected parameters:
-* `distro=<distro>` - a name for the "distro", used to locate the signing keys
+* `distro=<distro>` - a name for the "distro", used to locate the signing keys (ignored and may be ommited for `backend=pkcs11`)
 * `sw-description=<body>` - the contents of the `sw-description` file to have signatures included
+
+Optional parameters:
+* `method=<method>` - may be `RSA` or `CMS` defults to `RSA` if ommited
+* `backend=<backend-type>` - backend can be pkcs11 or ssl, defaults to ssl if ommitted
+* `key-uri=<pkcs11 key uri>` - key uri required for `backend=pkcs11`
+* `cert-uri=<pkcs11 key uri>` - key uri required for `backend=pkcs11` & `method=CMS`
 
 Response: a `sw-description` file with signatures inserted
 

--- a/doc/swupdsign.md
+++ b/doc/swupdsign.md
@@ -27,7 +27,7 @@ Request type: `POST`
 Endpoint: `/sign/swupdate`
 
 Expected parameters:
-* `distro=<distro>` - a name for the "distro", used to locate the signing keys (ignored and may be ommited for `backend=pkcs11`)
+* `distro=<distro>` - a name for the "distro", used to locate the signing keys
 * `sw-description=<body>` - the contents of the `sw-description` file to have signatures included
 
 Optional parameters:

--- a/doc/swupdsign.md
+++ b/doc/swupdsign.md
@@ -31,10 +31,9 @@ Expected parameters:
 * `sw-description=<body>` - the contents of the `sw-description` file to have signatures included
 
 Optional parameters:
-* `method=<method>` - may be `RSA` or `CMS` defults to `RSA` if ommited
-* `backend=<backend-type>` - backend can be pkcs11 or ssl, defaults to ssl if ommitted
-* `key-uri=<pkcs11 key uri>` - key uri required for `backend=pkcs11`
-* `cert-uri=<pkcs11 key uri>` - key uri required for `backend=pkcs11` & `method=CMS`
+* `method=<method>` - may be `RSA` or `CMS`, defaults to `RSA` if omitted
+* `backend=<backend-type>` - backend can be `pkcs11` or `ssl`, defaults to `ssl` if omitted
+* `key-uri=<pkcs11 key uri>` - key URI required for `backend=pkcs11`
 
 Response: a `sw-description` file with signatures inserted
 

--- a/docker/Dockerfile.nxp-hsm
+++ b/docker/Dockerfile.nxp-hsm
@@ -1,18 +1,21 @@
-FROM ubuntu:18.04
+FROM ubuntu:24.04
+
+ARG YUBIHSM_SDK_VERSION=2026-04
 
 RUN apt-get update && apt-get install -y \
   device-tree-compiler \
   liblz4-tool \
-  python2.7 \
-  python3.7 \
-  python3.7-dev \
+  python3.12 \
+  python3.12-dev \
+  python3.12-venv \
   python3-pip \
   sbsigntool \
   && rm -rf /var/lib/apt/lists/*
 
-RUN update-alternatives --install /usr/bin/python  python  /usr/bin/python2.7 1
-RUN update-alternatives --install /usr/bin/python2 python2 /usr/bin/python2.7 1
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1
+
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 RUN pip3 install --upgrade pip
 
@@ -45,24 +48,12 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 # Add support for YubiHSM 2
-# --force-overwrite as libyubihsm-dev_2.4.2_amd64.deb and libykhsmauth-dev 2.4.2 both include /usr/include/ykhsmauth.h
+# --force-overwrite as libyubihsm-dev and libykhsmauth-dev both include /usr/include/ykhsmauth.h
 RUN mkdir -p /opt/yubico && \
-    wget -q -O - https://developers.yubico.com/YubiHSM2/Releases/yubihsm2-sdk-2023-11-ubuntu1804-amd64.tar.gz | \
+    wget -q -O - https://developers.yubico.com/YubiHSM2/Releases/yubihsm2-sdk-${YUBIHSM_SDK_VERSION}-ubuntu2404-amd64.tar.gz | \
     tar xzf - -C /opt/yubico && \
     cd /opt/yubico/yubihsm2-sdk && \
-    dpkg -i --force-overwrite \
-    ./libykhsmauth1_2.4.2_amd64.deb \
-    ./libyubihsm-http1_2.4.2_amd64.deb \
-    ./yubihsm-auth_2.4.2_amd64.deb \
-    ./yubihsm-shell_2.4.2_amd64.deb \
-    ./libykhsmauth-dev_2.4.2_amd64.deb \
-    ./libyubihsm-usb1_2.4.2_amd64.deb \
-    ./yubihsm-connector_3.0.4-1_amd64.deb \
-    ./yubihsm-wrap_2.4.2_amd64.deb \
-    ./libyubihsm1_2.4.2_amd64.deb \
-    ./yubihsm-pkcs11_2.4.2_amd64.deb \
-    ./libyubihsm-dev_2.4.2_amd64.deb \
-    ./yubihsm-setup_2.3.1-1_amd64.deb && \
+    dpkg -i --force-overwrite ./*.deb && \
     rm -rf /opt/yubico
 
 RUN yubihsm-connector install
@@ -71,8 +62,17 @@ RUN yubihsm-connector install
 RUN echo "priority: 10\nmodule: /usr/lib/x86_64-linux-gnu/pkcs11/yubihsm_pkcs11.so" > /usr/share/p11-kit/modules/yubihsm2.module && \
     echo "connector = http://127.0.0.1:12345\n" >> /etc/yubihsm_pkcs11.conf
 
-ENV PKCS11_MODULE=/usr/lib/x86_64-linux-gnu/p11-kit-proxy.so
+COPY docker/openssl.cnf /etc/ssl/openssl.cnf
+
+ENV LD_LIBRARY_PATH=/usr/lib
+ENV PKCS11_MODULE_PATH=/usr/lib/yubihsm_pkcs11.so
+ENV PKCS11_MODULE=/usr/lib/yubihsm_pkcs11.so
 ENV YUBIHSM_PKCS11_CONF=/etc/yubihsm_pkcs11.conf
+ENV OPENSSL_CONF=/etc/ssl/openssl.cnf
+
+RUN mkdir -p /usr/lib && \
+    test -e /usr/lib/yubihsm_pkcs11.so || \
+    ln -sf /usr/lib/x86_64-linux-gnu/pkcs11/yubihsm_pkcs11.so /usr/lib/yubihsm_pkcs11.so
 
 # Setup paths for openssl (found from running cst --version)
 RUN cd /opt && \
@@ -80,6 +80,6 @@ RUN cd /opt && \
     cd cst-ssl && \
     mkdir lib && \
     cd lib && \
-    ln -s /usr/lib/x86_64-linux-gnu/engines-1.1 engines-1.1
+    ln -s /usr/lib/x86_64-linux-gnu/engines-3 engines-1.1
 
 CMD [ "/bin/bash", "-c", "yubihsm-connector start && digsigserver --debug" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -99,19 +99,21 @@ To build the image :
 
     docker build . -f docker/Dockerfile.nxp-hsm -t digsigserver-nxp-hsm:latest
 
+This image has been updated and tested in limited capacity only. It may still
+require platform-specific adjustments depending on the host architecture and
+Docker builder configuration.
+
 ## Running
 
 For i.MX signing with the YubiHSM 2, the imx-cst-keys.tar.gz file only needs to contain the crts/SRK_table_1_2_3_4.bin file. The USB bus 
-must be shared with the host. Also the YUBIHSM_PASSWORD environment variable is set to the password set for the YubiHSM 2 with the prefix "0001" 
+must be shared with the host. Also the DIGSIGSERVER_YUBIHSM_PASSWORD environment variable is set to the password set for the YubiHSM 2 with the prefix "0001" 
 as this is the object id of the authentication object that pkcs11 uses to authenticate whith the token. So if the YubiHSM 2 password is 
 "password" and MACHINE is imx8mp, then the signing server would be started as follows :
 
 docker run -d \
   --restart unless-stopped \
   --privileged -v /dev/bus/usb:/dev/bus/usb \
-  --env "YUBIHSM_PASSWORD=0001password" \
+  --env "DIGSIGSERVER_YUBIHSM_PASSWORD=0001password" \
   -p 9999:9999 \
   --mount type=bind,source=$HOME/imx-cst-keys.tar.gz,target=/digsigserver/imx8mp/imxsign/imx-cst-keys.tar.gz,readonly \
   digsigserver-nxp-hsm:latest
-
-

--- a/docker/openssl.cnf
+++ b/docker/openssl.cnf
@@ -1,0 +1,14 @@
+openssl_conf = default_conf
+
+[default_conf]
+engines = engine_section
+
+[engine_section]
+pkcs11 = pkcs11_section
+
+[pkcs11_section]
+engine_id = pkcs11
+dynamic_path = /usr/lib/x86_64-linux-gnu/engines-3/libpkcs11.so
+MODULE_PATH = /usr/lib/yubihsm_pkcs11.so
+init = 1
+default_algorithms = ALL


### PR DESCRIPTION
## Summary

Add PKCS#11 backend support for FIT image and SWUpdate signing.

Also included:
- secret redaction in logs
- generic Sanic exception handling to avoid leaking internal errors
- FIT/SWUpdate API doc updates

## Notable changes

-  supports 
- FIT PKCS#11 requires 
- FIT signing supports optional  mapped to 
-  supports 
-  remains required for SWUpdate

## Draft note

Opening as draft for API/implementation review first.

I plan to handle Docker/runtime validation in later commits.