### PR TITLE
Enable device-tree to be signed with named key

### DIFF
--- a/digsigserver/server.py
+++ b/digsigserver/server.py
@@ -220,7 +220,7 @@ def attach_endpoints(app: Sanic):
             keyname = "dev"
         with tempfile.TemporaryDirectory() as workdir:
             try:
-                s = FitImageSigner(app, workdir, backend)
+                s = FitImageSigner(app, workdir, req.form.get("machine") or "imx", backend)
             except ValueError:
                 return text("Invalid parameters", status=400)
 

--- a/digsigserver/server.py
+++ b/digsigserver/server.py
@@ -224,8 +224,9 @@ def attach_endpoints(app: Sanic):
             except ValueError:
                 return text("Invalid parameters", status=400)
 
-            with open(os.path.join(workdir, "artifact"), "wb") as artifact:
-                artifact.write(f.body)
+            fitimage_path = os.path.join(workdir, "fitImage")
+            with open(fitimage_path, "wb") as fitimage:
+                fitimage.write(f.body)
 
             dtb_path = None
             if dtb:
@@ -236,15 +237,20 @@ def attach_endpoints(app: Sanic):
             outfile = tempfile.NamedTemporaryFile(delete=False)
             outfile.close()
             if await asyncio.get_running_loop().run_in_executor(None, s.sign,
-                                   artifact.name,
+                                   fitimage_path,
                                    dtb_path,
                                    req.form.get("external_data_offset"),
                                    req.form.get("mark_required"),
                                     req.form.get("algo"),
                                    keyname,
                                    req.form.get("comment")):
-                await return_file(req, artifact.name, "artifact.signed")
-                response = None
+                if dtb_path:
+                    dtb_name = os.path.basename(dtb_path)
+                    response = await return_tarball(req, workdir, return_filename="signed-fitImage.tar.gz",
+                                                   files_to_return=["fitImage", dtb_name])
+                else:
+                    await return_file(req, fitimage_path, "fitImage.signed")
+                    response = None
             else:
                 response = text("Signing error", status=500)
         return response

--- a/digsigserver/server.py
+++ b/digsigserver/server.py
@@ -211,6 +211,7 @@ def attach_endpoints(app: Sanic):
         f = validate_upload(req, "artifact")
         if not f:
             return text("Invalid artifact", status=400)
+        dtb = validate_upload(req, "dtb")
         backend = req.form.get("backend")
         keyname = req.form.get("keyname")
         if backend == "pkcs11" and not keyname:
@@ -226,11 +227,17 @@ def attach_endpoints(app: Sanic):
             with open(os.path.join(workdir, "artifact"), "wb") as artifact:
                 artifact.write(f.body)
 
+            dtb_path = None
+            if dtb:
+                dtb_path = os.path.join(workdir, dtb.name or "u-boot.dtb")
+                with open(dtb_path, "wb") as dtb_file:
+                    dtb_file.write(dtb.body)
+
             outfile = tempfile.NamedTemporaryFile(delete=False)
             outfile.close()
             if await asyncio.get_running_loop().run_in_executor(None, s.sign,
                                    artifact.name,
-                                   None,
+                                   dtb_path,
                                    req.form.get("external_data_offset"),
                                    req.form.get("mark_required"),
                                     req.form.get("algo"),

--- a/digsigserver/signers/fitimagesign.py
+++ b/digsigserver/signers/fitimagesign.py
@@ -12,8 +12,8 @@ class FitImageSigner (Signer):
 
     keytag = 'fitimagesign'
 
-    def __init__(self, app: Sanic, workdir: str, backend: str):
-        super().__init__(app, workdir, 'imx', backend, load_keys=backend != 'pkcs11')
+    def __init__(self, app: Sanic, workdir: str, machine: str = "imx", backend: str):
+        super().__init__(app, workdir, machine, backend, load_keys=backend != 'pkcs11')
 
     def _prepare_path(self) -> dict:
         env = dict(copy.deepcopy(os.environ))

--- a/digsigserver/signers/fitimagesign.py
+++ b/digsigserver/signers/fitimagesign.py
@@ -12,7 +12,7 @@ class FitImageSigner (Signer):
 
     keytag = 'fitimagesign'
 
-    def __init__(self, app: Sanic, workdir: str, machine: str = "imx", backend: str):
+    def __init__(self, app: Sanic, workdir: str, machine: str = "imx", backend: str = None):
         super().__init__(app, workdir, machine, backend, load_keys=backend != 'pkcs11')
 
     def _prepare_path(self) -> dict:

--- a/digsigserver/signers/fitimagesign.py
+++ b/digsigserver/signers/fitimagesign.py
@@ -1,5 +1,7 @@
 import os
 import copy
+import re
+import subprocess
 from typing import Optional
 from digsigserver.signers import Signer
 
@@ -20,19 +22,81 @@ class FitImageSigner (Signer):
             env['PATH'] += ':' + curpath
         return env
 
+    @staticmethod
+    def _normalize_keyname(keyname: Optional[str]) -> Optional[str]:
+        if not keyname:
+            return None
+        resolved = keyname.strip()
+        if not resolved:
+            return None
+        if resolved.endswith('.key'):
+            resolved = resolved[:-4]
+        return resolved or None
+
+    def _keyname_from_dtb(self, dtb: Optional[str]) -> Optional[str]:
+        if not dtb or not os.path.exists(dtb):
+            return None
+        try:
+            with open(dtb, 'rb') as f:
+                content = f.read().decode('latin-1', errors='ignore')
+        except OSError:
+            return None
+
+        # U-Boot signature keys are typically named key-<name>.
+        match = re.search(r'key-([A-Za-z0-9_.-]+)', content)
+        if match:
+            return match.group(1)
+        return None
+
+    def _keyname_from_fitimage(self, fitimage: str, env: dict) -> Optional[str]:
+        try:
+            proc = subprocess.run(
+                ['mkimage', '-l', fitimage],
+                stdin=subprocess.DEVNULL,
+                cwd=self.workdir,
+                env=env,
+                check=True,
+                capture_output=True,
+                encoding='utf-8'
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return None
+
+        # Example: "Sign algo:    sha256,rsa2048:dev_vb"
+        match = re.search(r'Sign algo:\s+[^:\n]+:([A-Za-z0-9_.-]+)', proc.stdout)
+        if match:
+            return match.group(1)
+        return None
+
+    def _resolve_keyname(self, keyname: Optional[str], dtb: Optional[str], fitimage: str, env: dict) -> str:
+        resolved = self._normalize_keyname(keyname)
+        if resolved:
+            return resolved
+        resolved = self._keyname_from_dtb(dtb)
+        if resolved:
+            logger.info("Resolved fitImage keyname from dtb: %s", resolved)
+            return resolved
+        resolved = self._keyname_from_fitimage(fitimage, env)
+        if resolved:
+            logger.info("Resolved fitImage keyname from fitImage metadata: %s", resolved)
+            return resolved
+        logger.info("Using default fitImage keyname: dev")
+        return 'dev'
+
     def sign(self, fitimage: str,
              dtb: Optional[str],
              external_data_offset: Optional[str],
              mark_required: Optional[bool],
              algo: Optional[str],
-             keyname: str = "dev",
+             keyname: Optional[str] = None,
              comment: Optional[str] = None) -> bool:
         env = self._prepare_path()
+        selected_keyname = self._resolve_keyname(keyname, dtb, fitimage, env)
         if self.backend == "pkcs11":
             keyname = keyname.replace('pin-value=password', 'pin-value=' + self.app.config.get('YUBIHSM_PASSWORD'))
-            cmd = ['mkimage', '-E', '-F', '-N', 'pkcs11', '-k', keyname, '-v']
+            cmd = ['mkimage', '-E', '-F', '-N', 'pkcs11', '-k', selected_keyname, '-v']
         else:
-            private_key = self.keys.get("{}.key".format(keyname))
+            private_key = self.keys.get("{}.key".format(selected_keyname))
             cmd = ['mkimage', '-F', '-k', os.path.dirname(private_key)]
 
         if comment:

--- a/digsigserver/signers/fitimagesign.py
+++ b/digsigserver/signers/fitimagesign.py
@@ -97,6 +97,7 @@ class FitImageSigner (Signer):
             cmd = ['mkimage', '-E', '-F', '-N', 'pkcs11', '-k', selected_keyname, '-v']
         else:
             private_key = self.keys.get("{}.key".format(selected_keyname))
+            self.keys.get("{}.crt".format(selected_keyname))
             cmd = ['mkimage', '-F', '-k', os.path.dirname(private_key)]
 
         if comment:

--- a/doc/fitimage.md
+++ b/doc/fitimage.md
@@ -33,16 +33,19 @@ Optional parameters:
 Response: signed binary
 
 Example usage:
-    curl --connect-timeout 30 --max-time 1800 --retry 1 --fail -X POST \
-        -F external_data_offset=2000 -F "artifact=@fitImage" \
-        -F mark_required=true -F machine=tegra -F keyname=devkey \
-        --output fitImage.signed http://$DIGSIG_SERVER_IP:$DIGSIG_SERVER_PORT/sign/fitimage
+```bash
+curl --connect-timeout 30 --max-time 1800 --retry 1 --fail -X POST \
+    -F external_data_offset=2000 -F "artifact=@fitImage" \
+    -F mark_required=true -F machine=tegra -F keyname=devkey \
+    --output fitImage.signed http://$DIGSIG_SERVER_IP:$DIGSIG_SERVER_PORT/sign/fitimage
+``` 
 
-If the `dtb` parameter is specified, a tarball is return containing the signed binary and the dtb containing the public-key
+If the `dtb` parameter is specified, a tarball is returned containing the signed binary and the dtb containing the public-key
 
 Example usage:
-    curl --connect-timeout 30 --max-time 1800 --retry 1 --fail -X POST \
-        -F external_data_offset=2000 -F "artifact=@fitImage" -F "dtb=@u-boot.dtb \
-        -F mark_required=true -F machine=tegra -F keyname=devkey \
-        --output artifacts.tar.gz http://$DIGSIG_SERVER_IP:$DIGSIG_SERVER_PORT/sign/fitimage
-
+```bash
+curl --connect-timeout 30 --max-time 1800 --retry 1 --fail -X POST \
+    -F external_data_offset=2000 -F "artifact=@fitImage" -F "dtb=@u-boot.dtb \
+    -F mark_required=true -F machine=tegra -F keyname=devkey \
+    --output artifacts.tar.gz http://$DIGSIG_SERVER_IP:$DIGSIG_SERVER_PORT/sign/fitimage
+```

--- a/doc/fitimage.md
+++ b/doc/fitimage.md
@@ -8,6 +8,7 @@ The private key used for signing the fitImage is expected in the following locat
 
     ${DIGSIGSERVER_KEYFILE_URI}/imx/dev.key
 
+The `imx` path is the default but can be customized with REST API parameter.
 The name of the key can be customized with a REST API parameter, otherwise `dev` is default.
 
 ## REST API endpoint
@@ -23,19 +24,25 @@ Optional parameters:
 * `external_data_offset=<offset>` - external data offset to be used during FIT signing
 * `mark_required=<any value>` - if this parameter exists the key will be marked as required
 * `algo=<signing algorithm>` - customize the signing algorithm
-* `comment=<text>` - add a comment to the FIT signature node
+* `machine=<machine name>` - customize the key path
 * `keyname=<name of the key to use or pkcs11 uri>` - specify a keyname other than `dev`; required for `backend=pkcs11`
+* `comment=<text>` - add a comment to the FIT signature node
 * `backend=<backend-type>` - backend can be `pkcs11` or `ssl`, defaults to `ssl` if omitted
+* `dtb=<device tree blob>` - a device tree blob in which the public-key is injected.
 
 Response: signed binary
 
 Example usage:
     curl --connect-timeout 30 --max-time 1800 --retry 1 --fail -X POST \
         -F external_data_offset=2000 -F "artifact=@fitImage" \
-        -F mark_required=true -F keyname=devkey \
+        -F mark_required=true -F machine=tegra -F keyname=devkey \
         --output fitImage.signed http://$DIGSIG_SERVER_IP:$DIGSIG_SERVER_PORT/sign/fitimage
 
+If the `dtb` parameter is specified, a tarball is return containing the signed binary and the dtb containing the public-key
 
-## Future improvements
-* Enable including a device tree blob in which the public key is injected.
-* Change the `imx` "machine" to something more logical, this is not machine dependent
+Example usage:
+    curl --connect-timeout 30 --max-time 1800 --retry 1 --fail -X POST \
+        -F external_data_offset=2000 -F "artifact=@fitImage" -F "dtb=@u-boot.dtb \
+        -F mark_required=true -F machine=tegra -F keyname=devkey \
+        --output artifacts.tar.gz http://$DIGSIG_SERVER_IP:$DIGSIG_SERVER_PORT/sign/fitimage
+


### PR DESCRIPTION

* Add ability to provide a DTB in wich the public key will be added.
  If a DTB is provided, a tarball with both fitimage and dtb will be returned.
* Allow to provide a key name instead of the forced `imx` one.
  keyname can be taken from request, dtb or fitimage.